### PR TITLE
const.py: update some inconsistencies

### DIFF
--- a/custom_components/lambda_heat_pumps/const.py
+++ b/custom_components/lambda_heat_pumps/const.py
@@ -152,8 +152,8 @@ HP_SENSOR_TEMPLATES = {
     "volume_flow_heat_sink": {
         "relative_address": 6,
         "name": "Volume Flow Heat Sink",
-        "unit": "l/h",
-        "scale": 1,
+        "unit": "l/min",
+        "scale": 0.01,
         "precision": 1,
         "data_type": "int16",
         "firmware_version": 1,
@@ -177,7 +177,7 @@ HP_SENSOR_TEMPLATES = {
         "relative_address": 8,
         "name": "Energy Source Outlet Temperature",
         "unit": "°C",
-        "scale": 0.1,
+        "scale": 0.01,
         "precision": 1,
         "data_type": "int16",
         "firmware_version": 1,
@@ -682,7 +682,7 @@ BOIL_SENSOR_TEMPLATES = {
         "data_type": "int16",
         "firmware_version": 1,
         "device_type": "boil",
-        "writeable": False,
+        "writeable": True,
         "state_class": "measurement",
     },
     "dummy_fw2": {
@@ -822,7 +822,7 @@ BUFF_SENSOR_TEMPLATES = {
         "data_type": "int16",
         "firmware_version": 1,
         "device_type": "buff",
-        "writeable": False,
+        "writeable": True,
     },
 }
 
@@ -895,6 +895,28 @@ SOL_SENSOR_TEMPLATES = {
         "device_type": "sol",
         "writeable": False,
     },
+    "maximum_buffer_temperature": {
+        "relative_address": 50,
+        "name": "Maximum Buffer Temperature",
+        "unit": "°C",
+        "scale": 0.1,
+        "precision": 1,
+        "data_type": "int16",
+        "firmware_version": 1,
+        "device_type": "sol",
+        "writeable": True,
+    },
+    "buffer_changeover_temperature": {
+        "relative_address": 51,
+        "name": "Buffer Changeover Temperature",
+        "unit": "°C",
+        "scale": 0.1,
+        "precision": 1,
+        "data_type": "int16",
+        "firmware_version": 1,
+        "device_type": "sol",
+        "writeable": True,
+    },
 }
 
 # Heating Circuit Sensors
@@ -956,7 +978,7 @@ HC_SENSOR_TEMPLATES = {
         "data_type": "int16",
         "firmware_version": 1,
         "device_type": "hc",
-        "writeable": False,
+        "writeable": True,
         "state_class": "measurement",
     },
     "set_flow_line_temperature": {
@@ -968,7 +990,7 @@ HC_SENSOR_TEMPLATES = {
         "data_type": "int16",
         "firmware_version": 1,
         "device_type": "hc",
-        "writeable": False,
+        "writeable": True,
         "state_class": "measurement",
     },
     "operating_mode": {
@@ -980,7 +1002,7 @@ HC_SENSOR_TEMPLATES = {
         "data_type": "int16",
         "firmware_version": 1,
         "device_type": "hc",
-        "writeable": False,
+        "writeable": True,
         "txt_mapping": True,
     },
     "set_flow_line_offset_temperature": {
@@ -992,7 +1014,7 @@ HC_SENSOR_TEMPLATES = {
         "data_type": "int16",
         "firmware_version": 1,
         "device_type": "hc",
-        "writeable": False,
+        "writeable": True,
         "state_class": "measurement",
     },
     "target_room_temperature": {
@@ -1016,7 +1038,7 @@ HC_SENSOR_TEMPLATES = {
         "data_type": "int16",
         "firmware_version": 1,
         "device_type": "hc",
-        "writeable": False,
+        "writeable": True,
         "state_class": "measurement",
     },
     "target_temp_flow_line": {


### PR DESCRIPTION
Hi!
Thanks for your effort - I also started an integration like this (locally), but didn't have that time to finish it :-/
So I'll just contribute ;) 

I just skimmed through the entries and found some inconsistencies in the data types.
…although not related to the 32bit endianess issue :-(

Is it on purpose that the heatpump register `1*14` "Modbus request release password" is missing?
(I also left it out because I don't know if this is needed)

please check!

btw. Just writing english because I'm used to do this on github. I can definitely change to german if that's easier for you or more consistent for this repository ;)
…greetings from austria