### PR TITLE
Making actual high temperature of the buffer a measurement

### DIFF
--- a/custom_components/lambda_heat_pumps/const.py
+++ b/custom_components/lambda_heat_pumps/const.py
@@ -736,6 +736,7 @@ BUFF_SENSOR_TEMPLATES = {
         "firmware_version": 1,
         "device_type": "buff",
         "writeable": False,
+        "state_class": "measurement",
     },
     "actual_low_temperature": {
         "relative_address": 3,


### PR DESCRIPTION
Allow statistic diagram for this sensor. Statistic diagrams require a state class. It might also make sense to add some more entities of the buffer as measurement?