### PR TITLE
Fix double-offset in heating curve calculation

### DIFF
--- a/custom_components/lambda_heat_pumps/template_sensor.py
+++ b/custom_components/lambda_heat_pumps/template_sensor.py
@@ -826,7 +826,6 @@ class LambdaHeatingCurveCalcSensor(CoordinatorEntity, SensorEntity):
             if raw_offset is not None:
                 try:
                     flow_line_offset = float(raw_offset)
-                    result += flow_line_offset
                 except (TypeError, ValueError):
                     _LOGGER.warning(
                         "%s — Flow-Line-Offset (%s) konnte nicht verarbeitet werden: %s",


### PR DESCRIPTION
## Problem

The flow line offset (register 50, `set_flow_line_offset_temperature`) is applied twice:

1. The Lambda heat pump applies the offset **internally** when computing the flow line temperature setpoint (register 7)
2. The `LambdaHeatingCurveCalcSensor` in `template_sensor.py` adds the same offset **again** to its calculated result (`result += flow_line_offset`, line 829)

This causes the calculated heating curve sensor to show a value that is too high by exactly the offset amount.

**Example:** With an offset of +1.5°C and a heating curve base of 29.2°C:
- Expected: 29.2 + 1.5 = **30.7°C**
- Actual: 29.2 + 1.5 + 1.5 = **32.2°C**

## Fix

Remove `result += flow_line_offset` from the heating curve calculation. The offset value is still read and stored as an attribute (`_last_flow_offset`) for display purposes.

Fixes #63