### PR TITLE
V2.4.0 new release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ scenes.yaml
 scripts.yaml
 secrets.yaml
 configuration.yaml
+docs/daskboard_Ammortisieerung.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@
 
 > **📚 Documentation**: A German documentation is currently being built at [https://guidojeuken-6512.github.io/lambda_heat_pumps](https://guidojeuken-6512.github.io/lambda_heat_pumps)
  
+### [2.4.0] - 2026-03-29
+
+#### Fixed
+- **Critical: Cycling offset re-applied on every cycle event**: `increment_cycling_counter()` was re-adding the full `cycling_offsets` YAML value on every detected mode change instead of once at startup. Offset logic removed from this function; sole responsibility now lies with `_apply_cycling_offset()` in `sensor.py`, which correctly uses differential tracking.
+- **Mode detection for cycling counters**: Fixed shared-state bug that caused cycle events to be missed.
+- **NameError in `increment_cycling_counter()`**: Operating mode transitions were detected but never counted due to a `cycling_entity` NameError.
+- **Energy offsets silently ignored**: `_apply_energy_offset()` was never called from `async_added_to_hass()`, causing configured energy offsets to have no effect at HA startup.
+
+#### Improvements
+- Configuration template (`lambda_wp_config.yaml`) extended with examples for negative offsets and thermal energy offset keys.
+- Migration system updated; 23 new tests added covering offset scenarios.
+- Documentation updated: negative offset usage documented, stale warning banners removed.
+
+---
+
 ### [2.3.4] - 2026-03-21
 Change to the logic for detecting compressor starts (cycling): The 'compressor_unit_rating' sensor is used and is queried more frequently.
 
@@ -300,6 +315,26 @@ This release contains significant changes to the Entity Registry and sensor nami
 
 > **📚 Dokumentation**: Eine deutsche Dokumentation wird derzeit unter [https://guidojeuken-6512.github.io/lambda_heat_pumps](https://guidojeuken-6512.github.io/lambda_heat_pumps) aufgebaut
 
+
+### [2.4.0] - 2026-03-29
+
+#### Behoben
+- **Kritisch: Cycling-Offset wurde bei jedem Zyklus erneut addiert**: `increment_cycling_counter()` hat den in `lambda_wp_config.yaml` konfigurierten `cycling_offsets`-Wert bei jeder erkannten Modusänderung neu aufaddiert statt einmalig beim Start. Die Offset-Logik wurde aus dieser Funktion entfernt; alleinige Verantwortung liegt jetzt bei `_apply_cycling_offset()` in `sensor.py`, das korrekt mit Differenz-Tracking arbeitet.
+- **Moduserkennung für Cycling-Zähler**: Fehler durch gemeinsam genutzten Zustand behoben, der dazu führte, dass Zyklusereignisse nicht erkannt wurden.
+- **NameError in `increment_cycling_counter()`**: Betriebsmodus-Übergänge wurden zwar erkannt, aber wegen eines `cycling_entity`-NameErrors nie gezählt.
+- **Energie-Offsets wurden lautlos ignoriert**: `_apply_energy_offset()` wurde nicht aus `async_added_to_hass()` aufgerufen, sodass konfigurierte Energie-Offsets beim HA-Start keine Wirkung hatten.
+
+#### Verbesserungen
+- Konfigurations-Template (`lambda_wp_config.yaml`) um Beispiele für negative Offsets und thermische Energie-Offset-Schlüssel erweitert.
+- Migrationssystem aktualisiert; 23 neue Tests für Offset-Szenarien hinzugefügt.
+- Dokumentation aktualisiert: Verwendung negativer Offsets dokumentiert, veraltete Warnhinweise entfernt.
+
+---
+
+### [2.3.4] - 2026-03-21
+Änderung an der Logik zur Erkennung von Kompressorstarts (Cycling): Der Sensor `compressor_unit_rating` wird verwendet und häufiger abgefragt.
+
+---
 
 ### [2.3] - 2026-XX-XX
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![maintainer](https://img.shields.io/badge/maintainer-%40GuidoJeuken--6512-blue.svg)](https://github.com/GuidoJeuken-6512)
 [![version](https://img.shields.io/badge/version-2.3.4-blue.svg)](https://github.com/GuidoJeuken-6512/lambda_heat_pumps/releases)
 [![license](https://img.shields.io/github/license/GuidoJeuken-6512/lambda_heat_pumps.svg)](LICENSE)
+![Usage](https://img.shields.io/badge/dynamic/json?color=9932CC&logo=home-assistant&label=usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.lambda_heat_pumps.total)
 
 
 <a href="https://www.paypal.com/donate/?hosted_button_id=P3N7RRC2SNQ48">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![maintainer](https://img.shields.io/badge/maintainer-%40GuidoJeuken--6512-blue.svg)](https://github.com/GuidoJeuken-6512)
-[![version](https://img.shields.io/badge/version-2.3.4-blue.svg)](https://github.com/GuidoJeuken-6512/lambda_heat_pumps/releases)
+[![version](https://img.shields.io/badge/version-2.4.0-blue.svg)](https://github.com/GuidoJeuken-6512/lambda_heat_pumps/releases)
 [![license](https://img.shields.io/github/license/GuidoJeuken-6512/lambda_heat_pumps.svg)](LICENSE)
 ![Usage](https://img.shields.io/badge/dynamic/json?color=9932CC&logo=home-assistant&label=usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.lambda_heat_pumps.total)
 

--- a/custom_components/lambda_heat_pumps/const_base.py
+++ b/custom_components/lambda_heat_pumps/const_base.py
@@ -213,20 +213,23 @@ LAMBDA_WP_CONFIG_TEMPLATE = """# Lambda WP configuration
 #  override_name: new_name_of_the_sensor_example
 
 # Cycling counter offsets for total sensors
-# These offsets are added to the calculated cycling counts
-# Useful when replacing heat pumps or resetting counters
+# These offsets are added to the calculated cycling counts once at HA start.
+# Useful when replacing heat pumps or resetting counters.
+# Positive values add to the total; negative values subtract.
 # Example:
 #cycling_offsets:
 #  hp1:
-#    heating_cycling_total: 0      # Offset for HP1 heating total cycles
-#    hot_water_cycling_total: 0    # Offset for HP1 hot water total cycles
-#    cooling_cycling_total: 0      # Offset for HP1 cooling total cycles
-#    defrost_cycling_total: 0      # Offset for HP1 defrost total cycles
+#    heating_cycling_total: 0               # Offset for HP1 heating total cycles
+#    hot_water_cycling_total: 0             # Offset for HP1 hot water total cycles
+#    cooling_cycling_total: 0               # Offset for HP1 cooling total cycles
+#    defrost_cycling_total: 0               # Offset for HP1 defrost total cycles
+#    compressor_start_cycling_total: 0      # Offset for HP1 compressor start total
 #  hp2:
-#    heating_cycling_total: 1500   # Example: HP2 already had 1500 heating cycles
-#    hot_water_cycling_total: 800  # Example: HP2 already had 800 hot water cycles
-#    cooling_cycling_total: 200    # Example: HP2 already had 200 cooling cycles
-#    defrost_cycling_total: 50     # Example: HP2 already had 50 defrost cycles
+#    heating_cycling_total: 1500            # Example: HP2 already had 1500 heating cycles
+#    hot_water_cycling_total: 800           # Example: HP2 already had 800 hot water cycles
+#    cooling_cycling_total: 200             # Example: HP2 already had 200 cooling cycles
+#    defrost_cycling_total: 50              # Example: HP2 already had 50 defrost cycles
+#    compressor_start_cycling_total: 5000   # Example: HP2 already had 5000 compressor starts
 
 # Energy consumption sensor configuration (Quellsensoren für den Energieverbrauch)
 # Diese Sensoren müssen den Gesamtverbrauch in Wh oder kWh anzeigen
@@ -241,21 +244,25 @@ LAMBDA_WP_CONFIG_TEMPLATE = """# Lambda WP configuration
 #    sensor_entity_id: "sensor.lambda_wp_verbrauch2"
 #    thermal_sensor_entity_id: "sensor.lambda_wp_waerme2"  # optional
 
-# Energy consumption offsets for total sensors (WICHTIG: Alle Werte müssen in kWh angegeben werden!)
-# Diese Offsets werden nur auf die TOTAL-Sensoren angewendet, nicht auf Daily/Monthly/Yearly
-# Nützlich beim Austausch von Wärmepumpen oder Zurücksetzen der Zähler
-# Beispiel mit Nachkommastellen:
+# Energy consumption offsets for total sensors (IMPORTANT: all values in kWh!)
+# Applied only to TOTAL sensors, not to Daily/Monthly/Yearly.
+# Useful when replacing heat pumps or resetting counters.
+# Positive values add to the total; negative values subtract.
+# Electrical offsets: {mode}_energy_total
+# Thermal offsets:    {mode}_thermal_energy_total  (optional)
 #energy_consumption_offsets:
 #  hp1:
-#    heating_energy_total: 0.0       # kWh offset for HP1 heating total
-#    hot_water_energy_total: 0.0     # kWh offset for HP1 hot water total
-#    cooling_energy_total: 0.0       # kWh offset for HP1 cooling total
-#    defrost_energy_total: 0.0       # kWh offset for HP1 defrost total
+#    heating_energy_total: 0.0              # kWh offset for HP1 heating total (electrical)
+#    hot_water_energy_total: 0.0            # kWh offset for HP1 hot water total (electrical)
+#    cooling_energy_total: 0.0              # kWh offset for HP1 cooling total (electrical)
+#    defrost_energy_total: 0.0              # kWh offset for HP1 defrost total (electrical)
+#    heating_thermal_energy_total: 0.0      # kWh offset for HP1 heating total (thermal, optional)
+#    hot_water_thermal_energy_total: 0.0    # kWh offset for HP1 hot water total (thermal, optional)
 #  hp2:
-#    heating_energy_total: 150.5     # Beispiel: HP2 bereits 150,5 kWh Heizen verbraucht
-#    hot_water_energy_total: 45.25   # Beispiel: HP2 bereits 45,25 kWh Warmwasser verbraucht
-#    cooling_energy_total: 12.8      # Beispiel: HP2 bereits 12,8 kWh Kühlen verbraucht
-#    defrost_energy_total: 3.1       # Beispiel: HP2 bereits 3,1 kWh Abtauen verbraucht
+#    heating_energy_total: 150.5            # Example: HP2 already consumed 150.5 kWh heating
+#    hot_water_energy_total: 45.25          # Example: HP2 already consumed 45.25 kWh hot water
+#    cooling_energy_total: 12.8             # Example: HP2 already consumed 12.8 kWh cooling
+#    defrost_energy_total: 3.1              # Example: HP2 already consumed 3.1 kWh defrost
 
 # Modbus configuration
 # Register order for 32-bit registers (int32 sensors)

--- a/custom_components/lambda_heat_pumps/const_base.py
+++ b/custom_components/lambda_heat_pumps/const_base.py
@@ -258,11 +258,17 @@ LAMBDA_WP_CONFIG_TEMPLATE = """# Lambda WP configuration
 #    defrost_energy_total: 0.0              # kWh offset for HP1 defrost total (electrical)
 #    heating_thermal_energy_total: 0.0      # kWh offset for HP1 heating total (thermal, optional)
 #    hot_water_thermal_energy_total: 0.0    # kWh offset for HP1 hot water total (thermal, optional)
+#    cooling_thermal_energy_total: 0.0      # kWh offset for HP1 cooling total (thermal, optional)
+#    defrost_thermal_energy_total: 0.0      # kWh offset for HP1 defrost total (thermal, optional)
 #  hp2:
 #    heating_energy_total: 150.5            # Example: HP2 already consumed 150.5 kWh heating
 #    hot_water_energy_total: 45.25          # Example: HP2 already consumed 45.25 kWh hot water
 #    cooling_energy_total: 12.8             # Example: HP2 already consumed 12.8 kWh cooling
 #    defrost_energy_total: 3.1              # Example: HP2 already consumed 3.1 kWh defrost
+#    heating_thermal_energy_total: 620.0    # Example: HP2 already produced 620.0 kWh heating (thermal)
+#    hot_water_thermal_energy_total: 180.5  # Example: HP2 already produced 180.5 kWh hot water (thermal)
+#    cooling_thermal_energy_total: 45.2     # Example: HP2 already produced 45.2 kWh cooling (thermal)
+#    defrost_thermal_energy_total: 12.1     # Example: HP2 already produced 12.1 kWh defrost (thermal)
 
 # Modbus configuration
 # Register order for 32-bit registers (int32 sensors)

--- a/custom_components/lambda_heat_pumps/coordinator.py
+++ b/custom_components/lambda_heat_pumps/coordinator.py
@@ -85,6 +85,7 @@ class LambdaDataUpdateCoordinator(DataUpdateCoordinator):
         self._last_operating_state = {}
         self._energy_last_operating_state = {}  # Separate state for energy attribution (full update only)
         self._last_compressor_rating = {}  # Für compressor_unit_rating Flankenerkennung (0 → >0)
+        self._last_state = {}  # HP_STATE (reg 1002) – persisted across restarts
         self._heating_cycles = {}
         self._heating_energy = {}
         self._last_energy_update = {}
@@ -444,11 +445,13 @@ class LambdaDataUpdateCoordinator(DataUpdateCoordinator):
                     prev_monthly_val = energy_val
                 if "_yearly" in entity_id and prev_yearly_val > energy_val:
                     prev_yearly_val = energy_val
+                applied_offset_val = round(getattr(ent, "_applied_offset", 0.0), 4)
                 attrs = {
                     "energy_value": energy_val,
                     "yesterday_value": yesterday_val,
                     "previous_monthly_value": prev_monthly_val,
                     "previous_yearly_value": prev_yearly_val,
+                    "applied_offset": applied_offset_val,
                 }
                 out[entity_id] = {"state": round(float(state_val), 2), "attributes": attrs}
         except Exception as e:

--- a/custom_components/lambda_heat_pumps/coordinator.py
+++ b/custom_components/lambda_heat_pumps/coordinator.py
@@ -83,6 +83,7 @@ class LambdaDataUpdateCoordinator(DataUpdateCoordinator):
         self.hass = hass
         self.entry = entry
         self._last_operating_state = {}
+        self._energy_last_operating_state = {}  # Separate state for energy attribution (full update only)
         self._last_compressor_rating = {}  # Für compressor_unit_rating Flankenerkennung (0 → >0)
         self._heating_cycles = {}
         self._heating_energy = {}
@@ -386,6 +387,9 @@ class LambdaDataUpdateCoordinator(DataUpdateCoordinator):
             "heating_cycles": self._heating_cycles,
             "heating_energy": self._heating_energy,
             "last_operating_states": normalized_operating_states,
+            "energy_last_operating_states": self._normalize_operating_states(
+                getattr(self, "_energy_last_operating_state", {})
+            ),
             "last_states": normalized_states,
             "energy_consumption": self._energy_consumption,
             "last_energy_readings": self._last_energy_reading,
@@ -505,6 +509,7 @@ class LambdaDataUpdateCoordinator(DataUpdateCoordinator):
         
         # Lade persistierte State-Informationen
         self._last_operating_state = data.get("last_operating_states", {})
+        self._energy_last_operating_state = data.get("energy_last_operating_states", {})
         self._last_state = data.get("last_states", {})
         
         # Lade persistierte Energy Consumption Daten
@@ -2244,7 +2249,7 @@ class LambdaDataUpdateCoordinator(DataUpdateCoordinator):
             return
         last_reading_dict[f"hp{hp_idx}"] = current_energy_kwh
         # Get last operating state for this heat pump
-        last_state = self._last_operating_state.get(str(hp_idx), 0)
+        last_state = self._energy_last_operating_state.get(str(hp_idx), 0)
         mode_mapping = {
             0: "stby", 1: "heating", 2: "hot_water", 3: "cooling", 4: "stby", 5: "defrost",
         }
@@ -2267,7 +2272,7 @@ class LambdaDataUpdateCoordinator(DataUpdateCoordinator):
                         hp_idx, mode, energy_delta, last_energy, current_energy_kwh,
                     )
                     await increment_fn(hp_idx, mode, energy_delta)
-        self._last_operating_state[str(hp_idx)] = current_state
+        self._energy_last_operating_state[str(hp_idx)] = current_state
 
     async def _increment_energy_consumption(self, hp_idx, mode, energy_delta):
         """Increment energy consumption for a specific mode and heat pump."""

--- a/custom_components/lambda_heat_pumps/coordinator.py
+++ b/custom_components/lambda_heat_pumps/coordinator.py
@@ -1593,7 +1593,6 @@ class LambdaDataUpdateCoordinator(DataUpdateCoordinator):
                             hp_index=hp_idx,
                             name_prefix=self.entry.data.get("name", "eu08l"),
                             use_legacy_modbus_names=self._use_legacy_names,
-                            cycling_offsets=self._cycling_offsets,
                         )
                         old_count = cycles.get(hp_idx, 0)
                         if not isinstance(old_count, (int, float)):
@@ -1655,7 +1654,6 @@ class LambdaDataUpdateCoordinator(DataUpdateCoordinator):
                         hp_index=hp_idx,
                         name_prefix=self.entry.data.get("name", "eu08l"),
                         use_legacy_modbus_names=self._use_legacy_names,
-                        cycling_offsets=self._cycling_offsets,
                     )
                     old_count = cycles.get(hp_idx, 0)
                     if not isinstance(old_count, (int, float)):

--- a/custom_components/lambda_heat_pumps/manifest.json
+++ b/custom_components/lambda_heat_pumps/manifest.json
@@ -17,5 +17,5 @@
   "issue_tracker": "https://github.com/GuidoJeuken-6512/lambda_heat_pumps/issues",
   "requirements": ["pymodbus>=3.6.0"],
 
-  "version": "2.3.4"
+  "version": "2.4.0"
 }

--- a/custom_components/lambda_heat_pumps/migration.py
+++ b/custom_components/lambda_heat_pumps/migration.py
@@ -338,6 +338,38 @@ async def migrate_lambda_config_sections(hass: HomeAssistant) -> bool:
             content_n, ranges = _find_section_ranges_in_content(content)
             section_ranges = {name: (s, e) for s, e, name in ranges}
 
+        # Migrate cycling_offsets: add compressor_start_cycling_total after defrost_cycling_total if missing
+        if "cycling_offsets" in section_ranges:
+            s_co, e_co = section_ranges["cycling_offsets"]
+            section_text = content_n[s_co:e_co]
+            inserts = []
+            for match in re.finditer(r"\n((?:#\s+|\s+))defrost_cycling_total:[^\n]*", section_text):
+                line_end = section_text.find("\n", match.end())
+                if line_end == -1:
+                    line_end = len(section_text)
+                next_start = line_end + 1
+                next_end = section_text.find("\n", next_start)
+                if next_end == -1:
+                    next_end = len(section_text)
+                next_line = section_text[next_start:next_end] if next_start < len(section_text) else ""
+                if "compressor_start_cycling_total:" in next_line:
+                    continue
+                prefix = match.group(1)  # e.g. "#    " or "    "
+                new_line = "\n" + prefix + "compressor_start_cycling_total: 0      # Offset for compressor start total"
+                inserts.append((line_end, new_line))
+            for pos, new_line in sorted(inserts, key=lambda x: -x[0]):
+                section_text = section_text[:pos] + new_line + section_text[pos:]
+            if inserts:
+                content_n = content_n[:s_co] + section_text + content_n[e_co:]
+                content = content_n
+                content_modified = True
+                _LOGGER.info(
+                    "Added compressor_start_cycling_total line(s) to cycling_offsets block (%d entries)",
+                    len(inserts),
+                )
+                content_n, ranges = _find_section_ranges_in_content(content)
+                section_ranges = {name: (s, e) for s, e, name in ranges}
+
         template_sections = _extract_config_sections()
         template_order = list(template_sections.keys())
         first_section_start = min(r[0] for r in ranges) if ranges else len(content_n)

--- a/custom_components/lambda_heat_pumps/migration.py
+++ b/custom_components/lambda_heat_pumps/migration.py
@@ -370,6 +370,47 @@ async def migrate_lambda_config_sections(hass: HomeAssistant) -> bool:
                 content_n, ranges = _find_section_ranges_in_content(content)
                 section_ranges = {name: (s, e) for s, e, name in ranges}
 
+        # Migrate energy_consumption_offsets: add missing thermal_energy_total lines
+        # Chain: defrost_energy_total → heating_thermal → hot_water_thermal → cooling_thermal → defrost_thermal
+        _THERMAL_CHAIN = [
+            (r"\n((?:#\s+|\s+))defrost_energy_total:[^\n]*",          "heating_thermal_energy_total",   "0.0      # kWh offset for heating total (thermal, optional)"),
+            (r"\n((?:#\s+|\s+))heating_thermal_energy_total:[^\n]*",   "hot_water_thermal_energy_total", "0.0      # kWh offset for hot water total (thermal, optional)"),
+            (r"\n((?:#\s+|\s+))hot_water_thermal_energy_total:[^\n]*", "cooling_thermal_energy_total",   "0.0      # kWh offset for cooling total (thermal, optional)"),
+            (r"\n((?:#\s+|\s+))cooling_thermal_energy_total:[^\n]*",   "defrost_thermal_energy_total",   "0.0      # kWh offset for defrost total (thermal, optional)"),
+        ]
+        if "energy_consumption_offsets" in section_ranges:
+            s_eo, e_eo = section_ranges["energy_consumption_offsets"]
+            section_text = content_n[s_eo:e_eo]
+            thermal_inserts_total = 0
+            for anchor_pattern, new_key, new_comment in _THERMAL_CHAIN:
+                inserts = []
+                for match in re.finditer(anchor_pattern, section_text):
+                    line_end = section_text.find("\n", match.end())
+                    if line_end == -1:
+                        line_end = len(section_text)
+                    next_start = line_end + 1
+                    next_end = section_text.find("\n", next_start)
+                    if next_end == -1:
+                        next_end = len(section_text)
+                    next_line = section_text[next_start:next_end] if next_start < len(section_text) else ""
+                    if new_key + ":" in next_line:
+                        continue
+                    prefix = match.group(1)
+                    inserts.append((line_end, "\n" + prefix + f"{new_key}: {new_comment}"))
+                for pos, new_line in sorted(inserts, key=lambda x: -x[0]):
+                    section_text = section_text[:pos] + new_line + section_text[pos:]
+                thermal_inserts_total += len(inserts)
+            if thermal_inserts_total:
+                content_n = content_n[:s_eo] + section_text + content_n[e_eo:]
+                content = content_n
+                content_modified = True
+                _LOGGER.info(
+                    "Added %d thermal_energy_total line(s) to energy_consumption_offsets block",
+                    thermal_inserts_total,
+                )
+                content_n, ranges = _find_section_ranges_in_content(content)
+                section_ranges = {name: (s, e) for s, e, name in ranges}
+
         template_sections = _extract_config_sections()
         template_order = list(template_sections.keys())
         first_section_start = min(r[0] for r in ranges) if ranges else len(content_n)

--- a/custom_components/lambda_heat_pumps/sensor.py
+++ b/custom_components/lambda_heat_pumps/sensor.py
@@ -1292,6 +1292,11 @@ class LambdaEnergyConsumptionSensor(RestoreEntity, SensorEntity):
             self._apply_persisted_energy_state(our_state)
             self.async_write_ha_state()
 
+        # Apply energy offset LAST — after _apply_persisted_energy_state() may have
+        # overwritten _energy_value with the coordinator's raw persisted value.
+        if self._period == "total":
+            await self._apply_energy_offset()
+
         # Für Daily-Sensoren: Initialisiere Yesterday-Wert beim Start, falls notwendig
         # Total-Sensoren werden oft erst nach Daily-Sensoren registriert → 100ms + ggf. verzögerter Zweitlauf
         if self._period == "daily" and self._reset_interval == "daily":
@@ -1459,6 +1464,19 @@ class LambdaEnergyConsumptionSensor(RestoreEntity, SensorEntity):
         try:
             attrs = data.get("attributes") or {}
             self._energy_value = float(attrs.get("energy_value", self._energy_value))
+            # Restore applied_offset from coordinator JSON so _apply_energy_offset() uses the
+            # correct base: if coordinator JSON has energy_value WITH offset, applied_offset
+            # must match so the differential check gives 0 and no double-application occurs.
+            # If energy_value was present but applied_offset is missing (old JSON format,
+            # pre-fix), assume energy_value is the raw value and reset applied_offset to 0
+            # so _apply_energy_offset() re-applies the full offset.
+            if "applied_offset" in attrs:
+                self._applied_offset = float(attrs["applied_offset"])
+            elif "energy_value" in attrs:
+                # Coordinator overwrote _energy_value but has no applied_offset key (old format).
+                # The stored energy_value is the raw value — reset so full offset is applied.
+                self._applied_offset = 0.0
+            # else: attrs was empty, coordinator didn't overwrite anything → keep _applied_offset
             for period, cfg in ENERGY_PERIOD_CONFIG.items():
                 val = attrs.get(cfg["attr_name"])
                 if val is not None:
@@ -1608,8 +1626,10 @@ class LambdaEnergyConsumptionSensor(RestoreEntity, SensorEntity):
                 _LOGGER.debug("No energy consumption offsets found for device %s", device_key)
                 return
             
-            # Hole den aktuellen Offset für diesen Sensor
-            sensor_id = f"{self._mode}_energy_total"
+            # Hole den aktuellen Offset für diesen Sensor.
+            # self._sensor_id unterscheidet elektrisch (hot_water_energy_total) von
+            # thermisch (hot_water_thermal_energy_total) — direkt als Schlüssel verwenden.
+            sensor_id = self._sensor_id
             current_offset = energy_offsets[device_key].get(sensor_id, 0.0)
             
             # Hole den bereits angewendeten Offset aus den Attributen (wie bei Cycling)
@@ -1620,24 +1640,29 @@ class LambdaEnergyConsumptionSensor(RestoreEntity, SensorEntity):
             
             if offset_difference > 0:
                 # Apply only the difference to current value
+                old_value = self._energy_value
                 self._energy_value += float(offset_difference)
                 self._applied_offset = current_offset  # Update applied offset
                 self.async_write_ha_state()
-                _LOGGER.debug(
-                    "Applied energy offset for %s: +%.2f kWh (new total: %.2f kWh)",
-                    self.entity_id, offset_difference, self._energy_value,
+                _LOGGER.info(
+                    "Applied energy offset for %s: %.2f + %.2f = %.2f kWh (applied_offset: %.4f)",
+                    self.entity_id, old_value, offset_difference, self._energy_value, self._applied_offset,
                 )
             elif offset_difference < 0:
                 # Offset was reduced, subtract the difference
+                old_value = self._energy_value
                 self._energy_value += float(offset_difference)  # offset_difference is negative
                 self._applied_offset = current_offset
                 self.async_write_ha_state()
-                _LOGGER.debug(
-                    "Reduced energy offset for %s: %.2f kWh (new total: %.2f kWh)",
-                    self.entity_id, offset_difference, self._energy_value,
+                _LOGGER.info(
+                    "Reduced energy offset for %s: %.2f - %.2f = %.2f kWh (applied_offset: %.4f)",
+                    self.entity_id, old_value, abs(offset_difference), self._energy_value, self._applied_offset,
                 )
             else:
-                _LOGGER.debug("No offset change for %s", self.entity_id)
+                _LOGGER.debug(
+                    "No energy offset change for %s (current_offset=%.4f, applied_offset=%.4f, energy_value=%.2f)",
+                    self.entity_id, current_offset, applied_offset, self._energy_value,
+                )
         except Exception as e:
             _LOGGER.error("Error applying energy offset for %s: %s", self.entity_id, e)
 

--- a/custom_components/lambda_heat_pumps/utils.py
+++ b/custom_components/lambda_heat_pumps/utils.py
@@ -867,8 +867,10 @@ async def increment_cycling_counter(
             if state_warning_key in coordinator._cycling_warnings:
                 del coordinator._cycling_warnings[state_warning_key]
 
-        # Get current state
-        if state_obj.state in (None, STATE_UNKNOWN, "unknown"):
+        # Prefer entity's internal counter (authoritative); fall back to HA state machine
+        if cycling_entity is not None and hasattr(cycling_entity, "_cycling_value"):
+            current = cycling_entity._cycling_value or 0
+        elif state_obj.state in (None, STATE_UNKNOWN, "unknown"):
             current = 0
         else:
             try:

--- a/custom_components/lambda_heat_pumps/utils.py
+++ b/custom_components/lambda_heat_pumps/utils.py
@@ -771,12 +771,11 @@ async def increment_cycling_counter(
     hp_index: int,
     name_prefix: str,
     use_legacy_modbus_names: bool = True,
-    cycling_offsets: dict = None,
 ):
     """
     Increment ALL cycling counters for a given mode and heat pump index.
     This should be called only on a real flank (state change)!
-    
+
     Increments: Total, Daily, 2H, 4H sensors
 
     Args:
@@ -785,7 +784,6 @@ async def increment_cycling_counter(
         hp_index: Index of the heat pump (1-based)
         name_prefix: Name prefix (e.g. "eu08l")
         use_legacy_modbus_names: Use legacy entity naming
-        cycling_offsets: Optional dict with cycling offsets from config
     """
 
     device_prefix = f"hp{hp_index}"
@@ -878,13 +876,6 @@ async def increment_cycling_counter(
             except Exception:
                 current = 0
 
-        # Offset nur für Total-Sensoren anwenden
-        offset = 0
-        if cycling_offsets is not None and sensor_id.endswith("_total"):
-            device_key = device_prefix
-            if device_key in cycling_offsets:
-                offset = int(cycling_offsets[device_key].get(sensor_id, 0))
-
         new_value = int(current + 1)
 
         # Versuche die Entity-Instanz zu finden
@@ -899,11 +890,10 @@ async def increment_cycling_counter(
         except Exception as e:
             _LOGGER.debug("Error searching for entity %s: %s", entity_id, e)
 
-        final_value = int(new_value + offset)
         if cycling_entity is not None and hasattr(cycling_entity, "set_cycling_value"):
-            cycling_entity.set_cycling_value(final_value)
+            cycling_entity.set_cycling_value(new_value)
             _LOGGER.info(
-                f"Cycling counter incremented: {entity_id} = {final_value} (was {current}, offset {offset}) [entity updated]"
+                f"Cycling counter incremented: {entity_id} = {new_value} (was {current}) [entity updated]"
             )
         else:
             # Fallback: State setzen wie bisher
@@ -911,10 +901,10 @@ async def increment_cycling_counter(
                 f"Cycling entity {entity_id} not found, using fallback state update"
             )
             hass.states.async_set(
-                entity_id, final_value, state_obj.attributes if state_obj else {}
+                entity_id, new_value, state_obj.attributes if state_obj else {}
             )
             _LOGGER.info(
-                f"Cycling counter incremented: {entity_id} = {final_value} (was {current}, offset {offset}) [state only]"
+                f"Cycling counter incremented: {entity_id} = {new_value} (was {current}) [state only]"
             )
 
         # Optional: Entity zum Update zwingen (z.B. für Recorder)

--- a/custom_components/lambda_heat_pumps/utils.py
+++ b/custom_components/lambda_heat_pumps/utils.py
@@ -457,6 +457,32 @@ async def load_lambda_config(hass: HomeAssistant) -> dict:
                 _LOGGER.error("Invalid energy_consumption_offsets format: %s", e)
                 energy_consumption_offsets = {}
 
+        # Warn when only one of electrical/thermal offset is specified for a mode.
+        # Modes with both sensor types: heating, hot_water, cooling, defrost (not stby).
+        _THERMAL_MODES = ("heating", "hot_water", "cooling", "defrost")
+        for device, offsets in energy_consumption_offsets.items():
+            if not isinstance(offsets, dict):
+                continue
+            for mode in _THERMAL_MODES:
+                elec_key = f"{mode}_energy_total"
+                therm_key = f"{mode}_thermal_energy_total"
+                elec_val = float(offsets.get(elec_key, 0.0))
+                therm_val = float(offsets.get(therm_key, 0.0))
+                if elec_val != 0.0 and therm_val == 0.0:
+                    _LOGGER.warning(
+                        "energy_consumption_offsets [%s]: %s is set (%.4f) but %s is 0 or missing — "
+                        "thermal energy sensor will not receive an offset. "
+                        "Add %s: <value> if a thermal offset is intended.",
+                        device, elec_key, elec_val, therm_key, therm_key,
+                    )
+                elif therm_val != 0.0 and elec_val == 0.0:
+                    _LOGGER.warning(
+                        "energy_consumption_offsets [%s]: %s is set (%.4f) but %s is 0 or missing — "
+                        "electrical energy sensor will not receive an offset. "
+                        "Add %s: <value> if an electrical offset is intended.",
+                        device, therm_key, therm_val, elec_key, elec_key,
+                    )
+
         _LOGGER.debug(
             "Loaded Lambda config: %d disabled registers, %d sensor "
             "overrides, %d cycling device offsets, %d energy consumption device offsets",
@@ -867,6 +893,18 @@ async def increment_cycling_counter(
             if state_warning_key in coordinator._cycling_warnings:
                 del coordinator._cycling_warnings[state_warning_key]
 
+        # Versuche die Entity-Instanz zu finden
+        cycling_entity = None
+        try:
+            # Suche in der neuen Cycling-Entities-Struktur
+            for entry_id, comp_data in hass.data.get("lambda_heat_pumps", {}).items():
+                if isinstance(comp_data, dict) and "cycling_entities" in comp_data:
+                    cycling_entity = comp_data["cycling_entities"].get(entity_id)
+                    if cycling_entity:
+                        break
+        except Exception as e:
+            _LOGGER.debug("Error searching for entity %s: %s", entity_id, e)
+
         # Prefer entity's internal counter (authoritative); fall back to HA state machine
         if cycling_entity is not None and hasattr(cycling_entity, "_cycling_value"):
             current = cycling_entity._cycling_value or 0
@@ -879,18 +917,6 @@ async def increment_cycling_counter(
                 current = 0
 
         new_value = int(current + 1)
-
-        # Versuche die Entity-Instanz zu finden
-        cycling_entity = None
-        try:
-            # Suche in der neuen Cycling-Entities-Struktur
-            for entry_id, comp_data in hass.data.get("lambda_heat_pumps", {}).items():
-                if isinstance(comp_data, dict) and "cycling_entities" in comp_data:
-                    cycling_entity = comp_data["cycling_entities"].get(entity_id)
-                    if cycling_entity:
-                        break
-        except Exception as e:
-            _LOGGER.debug("Error searching for entity %s: %s", entity_id, e)
 
         if cycling_entity is not None and hasattr(cycling_entity, "set_cycling_value"):
             cycling_entity.set_cycling_value(new_value)

--- a/docs/analysis/sensor_state_class_fix.md
+++ b/docs/analysis/sensor_state_class_fix.md
@@ -1,0 +1,62 @@
+# Sensor state_class Fix — Lambda Heat Pump Integration
+
+## Warning
+Historical Date will be lost for all changed entities
+
+
+## Context
+Home Assistant stores long-term statistics only for sensors that have a `state_class` set. The class must be semantically correct:
+- `measurement` — instantaneous values that can go up/down (temperatures, flow rates, %, COP)
+- `total` — cumulative counters with a `last_reset` (e.g., daily energy periods)
+- `total_increasing` — monotonically increasing counters (e.g., accumulated energy)
+
+Several sensors in `const_sensor.py` are incorrectly assigned `state_class: "total"` for values that are **not** cumulative counters. HA will attempt to track these as resettable totals, producing incorrect statistics (and logs warnings for `total` sensors with no unit). The fix is to change them to `"measurement"`.
+
+## Issues Found
+
+All in `custom_components/lambda_heat_pumps/const_sensor.py`:
+
+| Dict | Key | Current | Unit | Correct | Reason |
+|------|-----|---------|------|---------|--------|
+| `HP_SENSOR_TEMPLATES` | `error_number` | `total` | None | `measurement` | Error code, fluctuates freely |
+| `HP_SENSOR_TEMPLATES` | `volume_flow_heat_sink` | `total` | l/h | `measurement` | Instantaneous flow rate |
+| `HP_SENSOR_TEMPLATES` | `volume_flow_energy_source` | `total` | l/min | `measurement` | Instantaneous flow rate |
+| `HP_SENSOR_TEMPLATES` | `compressor_unit_rating` | `total` | % | `measurement` | Instantaneous percentage |
+| `HP_SENSOR_TEMPLATES` | `cop` | `total` | None | `measurement` | Instantaneous COP ratio |
+| `HP_SENSOR_TEMPLATES` | `request_type` | `total` | None | `measurement` | Numeric enum code |
+| `BOIL_SENSOR_TEMPLATES` | `error_number` | `total` | None | `measurement` | Error code |
+| `BUFF_SENSOR_TEMPLATES` | `error_number` | `total` | None | `measurement` | Error code |
+| `SOL_SENSOR_TEMPLATES` | `error_number` | `total` | None | `measurement` | Error code |
+| `HC_SENSOR_TEMPLATES` | `error_number` | `total` | None | `measurement` | Error code |
+| `SENSOR_TYPES` | `ambient_error_number` | `total` | None | `measurement` | Error code |
+| `SENSOR_TYPES` | `emgr_error_number` | `total` | None | `measurement` | Error code |
+
+**Out of scope:** Text/enum sensors (`operating_state`, `relais_state_2nd_heating_stage`, etc.) intentionally have no `state_class` — HA statistics require numeric values, so these cannot be included in long-term statistics. They will remain as-is.
+
+## File to Modify
+- `custom_components/lambda_heat_pumps/const_sensor.py`
+
+## Changes
+12 targeted edits: change `"state_class": "total"` → `"state_class": "measurement"` for each sensor listed above. No other changes needed.
+
+## Impact on Existing Historical Data
+
+When `state_class` changes for a sensor, HA detects a **metadata mismatch** in its `statistics_meta` table:
+
+**Sensors with `total` + no unit** (`error_number` × 5, `ambient_error_number`, `emgr_error_number`, `cop`, `request_type`):
+- HA almost certainly was **not** recording long-term statistics for these at all — `total` sensors without a unit cause HA to skip statistics silently (and log warnings internally). No existing statistics data to lose.
+- After the fix, HA will start recording them correctly as `measurement` statistics.
+
+**Sensors with `total` + unit** (`volume_flow_heat_sink` l/h, `volume_flow_energy_source` l/min, `compressor_unit_rating` %):
+- HA **may** have been recording statistics for these, but treating cumulative/rising behavior as a "total" — incorrect data.
+- After the fix, HA will detect the `state_class` metadata mismatch and show these sensors in **Developer Tools → Statistics** as needing attention.
+- Action needed: go to **Developer Tools → Statistics**, find the 3 sensors, and click **Fix issue** to clear the old malformed metadata. New data will then be recorded correctly as `measurement`.
+- Old incorrect statistics rows remain in the DB but are effectively abandoned — they won't appear in history graphs once the metadata is corrected.
+
+**No data loss risk** — short-term history in the `states` table is entirely unaffected by this change.
+
+## Verification
+1. Restart HA after deploying the change
+2. Check `home-assistant.log` — warnings about `total` sensors without units should be gone
+3. Open **Developer Tools → Statistics** in HA and confirm the 12 sensors now appear with correct `state_class: measurement` and are accumulating long-term statistics
+4. For the 3 sensors with `total` + unit: go to **Developer Tools → Statistics** and click **Fix issue** on any metadata mismatch warnings

--- a/docs/docs/Anwender/Energieverbrauchsberechnung.md
+++ b/docs/docs/Anwender/Energieverbrauchsberechnung.md
@@ -4,6 +4,8 @@ title: "Energie- und Wärmeverbrauchsberechnung"
 
 # Energie- und Wärmeverbrauchsberechnung
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda Heat Pumps Integration bietet umfassende Sensoren für **Stromverbrauch** (elektrische Energie) und **Wärmeabgabe** (thermische Energie) – jeweils nach Betriebsart (Heizen, Warmwasser, Kühlen, Abtauen) und Zeitraum (Total, Täglich, Monatlich, Jährlich). Damit ist eine vollständige Analyse des Energie- und Wärmeflusses Ihrer Wärmepumpe möglich.
 
 ⚠️ **Die Daten der Sensoren werden in der Integration berechnet, sie können nicht aus der Lambda ausgelesen werden. Daher können sie von der Werten in der Lambda abweichen. Zudem müssen sich die Tages- Monats- & Jahres-Werte erst aufbauen.**
@@ -63,8 +65,6 @@ energy_consumption_sensors:
 ```
 
 ### Energieverbrauchs-Offsets
-
-> ⚠️ ⚠️ **Achtung, die Funktion der Offsets für Sensoren ist fehlerhaft, bitte im Moment nicht einsetzen!**
 
 Offsets für historische Daten sind für alle Total-Sensoren möglich (siehe [Historische Daten übernehmen](historische-daten.md)):
 

--- a/docs/docs/Anwender/aktionen-modbus.md
+++ b/docs/docs/Anwender/aktionen-modbus.md
@@ -4,6 +4,8 @@ title: "Aktionen (read / write Modbus register)"
 
 # Aktionen (read / write Modbus register)
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda Heat Pumps Integration bietet Actions zum direkten Lesen und Schreiben von Modbus-Registern. Diese Funktionen sind nützlich für Automatisierungen, erweiterte Konfigurationen, Fehlerbehebung oder spezielle Anwendungsfälle.
 
 ## Verfügbare Actionen

--- a/docs/docs/Anwender/anpassungen-sensoren-firmware.md
+++ b/docs/docs/Anwender/anpassungen-sensoren-firmware.md
@@ -4,6 +4,8 @@ title: "Anpassungen der Sensoren abhängig von der Firmware"
 
 # Anpassungen der Sensoren abhängig von der Firmware
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda Heat Pumps Integration erstellt automatisch Sensoren basierend auf der erkannten Hardware und der konfigurierten Firmware-Version. Die Firmware-Version bestimmt, welche Sensoren verfügbar sind und welche Register gelesen werden können.
 
 ## Firmware-Version und Sensor-Verfügbarkeit

--- a/docs/docs/Anwender/attribute-sensoren-de.md
+++ b/docs/docs/Anwender/attribute-sensoren-de.md
@@ -4,6 +4,8 @@ title: "Attribute eines Sensors auslesen"
 
 # Attribute auslesen
 
+*Zuletzt geändert am 21.03.2026*
+
 Um die Attribute eines Sensors asuzulesen gibt es mehrere Möglichkeiten.
 
 ## Über den Sensor

--- a/docs/docs/Anwender/cop-sensoren.md
+++ b/docs/docs/Anwender/cop-sensoren.md
@@ -4,6 +4,8 @@ title: "COP-Sensoren (Leistungszahl)"
 
 # COP-Sensoren (Leistungszahl)
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda Heat Pumps Integration bietet **COP-Sensoren** (Coefficient of Performance / Leistungszahl), die das Verhältnis von erzeugter Wärme zu eingesetztem Strom anzeigen. Diese Sensoren helfen Ihnen, die Effizienz Ihrer Wärmepumpe zu überwachen und zu analysieren.
 
 ## Was ist COP?
@@ -185,8 +187,6 @@ severity:
 - Prüfen Sie die Quellsensoren (thermal_energy und energy) auf realistische Werte
 - Prüfen Sie die Einheiten (müssen beide in kWh sein)
 
-> ⚠️ ⚠️ **Achtung, die Funktion der Offsets für Sensoren ist fehlerhaft, bitte im Moment nicht einsetzen!** Offsets in der `lambda_wp_config.yaml` sollten derzeit nicht genutzt werden.
-
 ### COP-Sensor aktualisiert sich nicht
 
 **Ursache**: Quellsensoren aktualisieren sich nicht oder State-Tracking funktioniert nicht.
@@ -208,6 +208,6 @@ Für weitere Informationen zu den Energieverbrauchssensoren siehe [Energieverbra
 ## Nächste Schritte
 
 - [Energieverbrauchsberechnung](Energieverbrauchsberechnung.md) - Detaillierte Informationen zu den Quellsensoren
-- [Historische Daten übernehmen](historische-daten.md) - Offsets für historische Daten (⚠️ derzeit fehlerhaft, nicht nutzen)
+- [Historische Daten übernehmen](historische-daten.md) - Offsets für historische Daten
 - [Dashboard-Erstellung](features.md) - Weitere Dashboard-Beispiele
 

--- a/docs/docs/Anwender/debug-logs-erzeugen.md
+++ b/docs/docs/Anwender/debug-logs-erzeugen.md
@@ -4,6 +4,8 @@ title: "Debug Logs erzeugen"
 
 # Debug Logs erzeugen
 
+*Zuletzt geändert am 21.03.2026*
+
 Um Fehler zu analysieren oder detaillierte Abläufe der Integration zu prüfen, können Sie die Debug-Protokollierung für Lambda Heat Pumps einschalten.
 
 ## Debug-Logging aktivieren

--- a/docs/docs/Anwender/energiesensoren-entwicklerwerkzeuge.md
+++ b/docs/docs/Anwender/energiesensoren-entwicklerwerkzeuge.md
@@ -4,6 +4,8 @@ title: "Energiesensor-Werte anpassen (Entwicklerwerkzeuge)"
 
 # Energiesensor-Werte anpassen (Entwicklerwerkzeuge)
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda Heat Pumps Integration bietet **Energieverbrauchssensoren** nach Betriebsart (Heizen, Warmwasser, Kühlen, Abtauen): sowohl **elektrisch** (Stromverbrauch) als auch **thermisch** (Wärmeabgabe). Diese Werte können Sie bei Bedarf über die Home-Assistant-**Entwicklerwerkzeuge** anpassen – z. B. um Startwerte zu setzen oder Korrekturen vorzunehmen.
 
 ## Wann ist eine Anpassung sinnvoll?

--- a/docs/docs/Anwender/entitaeten_loeschen.md
+++ b/docs/docs/Anwender/entitaeten_loeschen.md
@@ -4,6 +4,8 @@ title: "Entitäten löschen"
 
 # Entitäten löschen
 
+*Zuletzt geändert am 21.03.2026*
+
 Entitäten, die von der Lambda-Integration nicht mehr bereitgestellt werden (z. B. nach einem Update oder nach Änderungen an der Firmware), können in Home Assistant gelöscht werden. Es gibt zwei Wege.
 
 ## Weg 1: Über die Entitätsseite

--- a/docs/docs/Anwender/features.md
+++ b/docs/docs/Anwender/features.md
@@ -4,6 +4,8 @@ title: "Features"
 
 # Features der Lambda Heat Pumps Integration
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda Heat Pumps Integration bietet umfassende Funktionen zur Steuerung und Überwachung Ihrer Lambda-Wärmepumpe über Home Assistant. Hier finden Sie eine Übersicht aller verfügbaren Features.
 
 ## 🔌 Modbus/TCP Kommunikation
@@ -42,10 +44,7 @@ Umfassende Zähler für alle Betriebsmodi:
 
 ### Funktionen
 - **Automatischer Reset**: Tägliche Sensoren werden automatisch um Mitternacht zurückgesetzt
-- **Offset-Konfiguration**: Anpassbare Zählerstände für Wärmepumpenwechsel oder Zählerrücksetzungen 
-
-> ⚠️ ⚠️ **Achtung, die Funktion der Offsets für Sensoren ist fehlerhaft, bitte im Moment nicht einsetzen!**
-
+- **Offset-Konfiguration**: Anpassbare Zählerstände für Wärmepumpenwechsel oder Zählerrücksetzungen
 
 ## ⚡ Energieverbrauchssensoren
 

--- a/docs/docs/Anwender/heizkurve.md
+++ b/docs/docs/Anwender/heizkurve.md
@@ -4,6 +4,8 @@ title: "Heizkurve / berechnete Vorlauftemperatur"
 
 # Heizkurve
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda Wärmepumpen Integration berechnet die Vorlauftemperatur des Heizkreises.
 Die Heizkurve bestimmt die Vorlauftemperatur basierend auf der Außentemperatur und ermöglicht eine energieeffiziente und komfortable Heizungssteuerung. Der Sensor "heating_curve_flow_line_temperature_calc" / "Heizkurve Vorlauf ber." wird dazu zur Verfügung gestellt.
 

--- a/docs/docs/Anwender/historische-daten.md
+++ b/docs/docs/Anwender/historische-daten.md
@@ -4,6 +4,8 @@ title: "Historische Daten übernehmen"
 
 # Historische Daten übernehmen
 
+*Zuletzt geändert am 21.03.2026*
+
 Wenn Sie eine Wärmepumpe austauschen oder die Zählerstände zurücksetzen, können Sie historische Daten in die Integration übernehmen. Dies ermöglicht es, die Kontinuität der Daten zu erhalten und historische Trends beizubehalten.
 
 Wenn Sie diese Integration neu installieren und vorher andere Lösungen im Einsatz hatten, die andere Entitäten zur Verfügung gestellt haben, so können Sie die historischen Daten der "alten" Sensoren auf die "neuen" umschreiben. Wie das funktioniert ist hier beschrieben: [Historische Werte neu zuordnen](https://homeassistant.com.de/homeassistant/homeassistant-historische-werte-neu-zuordnen/){:target="_blank" rel="noopener noreferrer"}

--- a/docs/docs/Anwender/historische-daten.md
+++ b/docs/docs/Anwender/historische-daten.md
@@ -4,8 +4,6 @@ title: "Historische Daten übernehmen"
 
 # Historische Daten übernehmen
 
-> ⚠️ ⚠️ **Achtung, die Funktion der Offsets für Sensoren ist fehlerhaft, bitte im Moment nicht einsetzen!**
-
 Wenn Sie eine Wärmepumpe austauschen oder die Zählerstände zurücksetzen, können Sie historische Daten in die Integration übernehmen. Dies ermöglicht es, die Kontinuität der Daten zu erhalten und historische Trends beizubehalten.
 
 Wenn Sie diese Integration neu installieren und vorher andere Lösungen im Einsatz hatten, die andere Entitäten zur Verfügung gestellt haben, so können Sie die historischen Daten der "alten" Sensoren auf die "neuen" umschreiben. Wie das funktioniert ist hier beschrieben: [Historische Werte neu zuordnen](https://homeassistant.com.de/homeassistant/homeassistant-historische-werte-neu-zuordnen/){:target="_blank" rel="noopener noreferrer"}
@@ -47,11 +45,11 @@ cycling_offsets:
 
 ### Funktionsweise
 
-1. **Beim Start**: Offsets werden auf Total-Sensoren angewendet, wenn sie initialisiert werden
-2. **Während des Betriebs**: Offsets werden zu jeder Inkrementierung hinzugefügt
+1. **Beim Start**: Offsets werden einmalig auf Total-Sensoren angewendet, sobald sie initialisiert werden
+2. **Differenz-Tracking**: Das System merkt sich den zuletzt angewendeten Offset (`applied_offset`). Bei jedem Neustart wird nur die Differenz zum vorherigen Wert addiert — keine Doppelanwendung möglich
 3. **Nur Total-Sensoren**: Offsets gelten nur für `*_cycling_total` Sensoren
 4. **Automatische Anwendung**: Offsets werden automatisch geladen und angewendet
-5. **Offset-Tracking**: System verfolgt angewendete Offsets, um Doppelanwendung zu verhindern
+5. **Positive und negative Werte**: Ein negativer Offset subtrahiert den Betrag vom Gesamtzähler (z. B. um einen zu hohen Ausgangswert zu korrigieren)
 
 ### Beispiel-Szenarien
 
@@ -98,23 +96,27 @@ Die Energieverbrauchs-Offsets werden in `lambda_wp_config.yaml` konfiguriert:
 ```yaml
 energy_consumption_offsets:
   hp1:
-    heating_energy_total: 0.0       # kWh Offset für HP1 Heizung Total
-    hot_water_energy_total: 0.0     # kWh Offset für HP1 Warmwasser Total
-    cooling_energy_total: 0.0      # kWh Offset für HP1 Kühlung Total
-    defrost_energy_total: 0.0       # kWh Offset für HP1 Abtau Total
+    heating_energy_total: 0.0            # kWh Offset für HP1 Heizung Total (elektrisch)
+    hot_water_energy_total: 0.0          # kWh Offset für HP1 Warmwasser Total (elektrisch)
+    cooling_energy_total: 0.0            # kWh Offset für HP1 Kühlung Total (elektrisch)
+    defrost_energy_total: 0.0            # kWh Offset für HP1 Abtau Total (elektrisch)
+    heating_thermal_energy_total: 0.0    # kWh Offset für HP1 Heizung Total (thermisch, optional)
+    hot_water_thermal_energy_total: 0.0  # kWh Offset für HP1 Warmwasser Total (thermisch, optional)
   hp2:
     heating_energy_total: 150.5     # Beispiel: HP2 verbrauchte bereits 150.5 kWh Heizung
     hot_water_energy_total: 45.25   # Beispiel: HP2 verbrauchte bereits 45.25 kWh Warmwasser
     cooling_energy_total: 12.8      # Beispiel: HP2 verbrauchte bereits 12.8 kWh Kühlung
-    defrost_energy_total: 3.1        # Beispiel: HP2 verbrauchte bereits 3.1 kWh Abtau
+    defrost_energy_total: 3.1       # Beispiel: HP2 verbrauchte bereits 3.1 kWh Abtau
 ```
 
 ### Funktionsweise
 
 1. **Nur Total-Sensoren**: Offsets werden nur auf `*_energy_total` Sensoren angewendet
-2. **Automatische Anwendung**: Offsets werden beim Start automatisch geladen und angewendet
+2. **Differenz-Tracking**: Das System merkt sich den zuletzt angewendeten Offset. Bei Neustart wird nur die Änderung zum vorherigen Wert addiert — keine Doppelanwendung möglich
 3. **Einheiten**: Alle Werte müssen in kWh (Kilowattstunden) angegeben werden
 4. **Dezimalnotation**: Verwenden Sie Punkt (.) als Dezimaltrennzeichen in YAML
+5. **Positive und negative Werte**: Ein negativer Offset subtrahiert den Betrag vom Gesamtwert
+6. **Thermische Sensoren**: Zusätzlich zu elektrischen Energie-Offsets können auch thermische Energie-Offsets (`{mode}_thermal_energy_total`) konfiguriert werden
 
 ### Beispiel-Szenarien
 

--- a/docs/docs/Anwender/historische_daten_loeschen.md
+++ b/docs/docs/Anwender/historische_daten_loeschen.md
@@ -4,6 +4,8 @@ title: "Historische Daten löschen"
 
 # Historische Daten löschen
 
+*Zuletzt geändert am 21.03.2026*
+
 Falls Sie die historischen Daten der Lambda Wärmepumpen Integration aus Home Assistant entfernen möchten, können Sie dies über die Home Assistant Benutzeroberfläche durchführen.
 
 

--- a/docs/docs/Anwender/index.md
+++ b/docs/docs/Anwender/index.md
@@ -3,6 +3,9 @@ title: "User Doku"
 ---
 
 # Lambda Wärmepumpen Integration für Home Assistant User Doku
+
+*Zuletzt geändert am 21.03.2026*
+
 In den Unterkapiteln finden Sie die Anwender Informationen zu der Integration.
 
 Die Doku wird so nach und nach wachsen.

--- a/docs/docs/Anwender/initiale-konfiguration.md
+++ b/docs/docs/Anwender/initiale-konfiguration.md
@@ -4,6 +4,8 @@ title: "Initiale Konfiguration"
 
 # Initiale Konfiguration
 
+*Zuletzt geändert am 21.03.2026*
+
 Nach der Installation der Lambda Heat Pumps Integration über HACS müssen Sie die Integration in Home Assistant einrichten. Dieser Abschnitt führt Sie durch den Konfigurationsprozess.
 
 ## Konfiguration über die Benutzeroberfläche

--- a/docs/docs/Anwender/installation.md
+++ b/docs/docs/Anwender/installation.md
@@ -4,6 +4,8 @@ title: "Installation"
 
 # Installation
 
+*Zuletzt geändert am 21.03.2026*
+
 ## Voraussetzungen
 
 ### HACS Installation

--- a/docs/docs/Anwender/konfiguration_loeschen.md
+++ b/docs/docs/Anwender/konfiguration_loeschen.md
@@ -4,6 +4,8 @@ title: "Konfiguration löschen"
 
 # Konfiguration löschen
 
+*Zuletzt geändert am 21.03.2026*
+
 Falls Sie die Lambda Wärmepumpen Integration aus Home Assistant entfernen möchten, können Sie dies über die Home Assistant Benutzeroberfläche durchführen.
 
 ## Integration entfernen

--- a/docs/docs/Anwender/lambda-wp-config.md
+++ b/docs/docs/Anwender/lambda-wp-config.md
@@ -100,8 +100,6 @@ sensors_names_override:
 
 ### 3. Cycling-Zähler-Offsets
 
-> ⚠️ ⚠️ **Achtung, die Funktion der Offsets für Sensoren ist fehlerhaft, bitte im Moment nicht einsetzen!**
-
 Fügt Offsets zu Cycling-Zählern für Total-Sensoren hinzu. Nützlich beim Austausch von Wärmepumpen oder Zurücksetzen von Zählern.
 
 ```yaml
@@ -124,6 +122,8 @@ cycling_offsets:
 - Wärmepumpen-Austausch: Zählerstand der vorherigen Pumpe hinzufügen
 - Zähler-Reset: Manuelle Resets kompensieren
 - Historische Daten erhalten: Kontinuität der Daten beibehalten
+
+**Hinweis:** Positive und **negative** Werte sind erlaubt. Ein negativer Offset subtrahiert den angegebenen Betrag vom Gesamtzähler (z. B. um einen zu hohen Ausgangswert zu korrigieren).
 
 **Beispiel-Szenario: Wärmepumpen-Austausch**
 ```yaml
@@ -174,8 +174,6 @@ Weitere Informationen: [Energieverbrauchsberechnung](Energieverbrauchsberechnung
 
 ### 5. Energieverbrauchs-Offsets
 
-> ⚠️ ⚠️ **Achtung, die Funktion der Offsets für Sensoren ist fehlerhaft, bitte im Moment nicht einsetzen!**
-
 Fügt Offsets zu Energieverbrauchswerten für Total-Sensoren hinzu. Nützlich beim Austausch von Wärmepumpen oder Zurücksetzen von Zählern.
 
 **⚠️ WICHTIG: Alle Werte müssen in kWh angegeben werden!**
@@ -183,10 +181,12 @@ Fügt Offsets zu Energieverbrauchswerten für Total-Sensoren hinzu. Nützlich be
 ```yaml
 energy_consumption_offsets:
   hp1:
-    heating_energy_total: 0.0       # kWh Offset für HP1 Heizungs-Total
-    hot_water_energy_total: 0.0     # kWh Offset für HP1 Warmwasser-Total
-    cooling_energy_total: 0.0       # kWh Offset für HP1 Kühlungs-Total
-    defrost_energy_total: 0.0       # kWh Offset für HP1 Abtau-Total
+    heating_energy_total: 0.0            # kWh Offset für HP1 Heizungs-Total (elektrisch)
+    hot_water_energy_total: 0.0          # kWh Offset für HP1 Warmwasser-Total (elektrisch)
+    cooling_energy_total: 0.0            # kWh Offset für HP1 Kühlungs-Total (elektrisch)
+    defrost_energy_total: 0.0            # kWh Offset für HP1 Abtau-Total (elektrisch)
+    heating_thermal_energy_total: 0.0    # kWh Offset für HP1 Heizungs-Total (thermisch, optional)
+    hot_water_thermal_energy_total: 0.0  # kWh Offset für HP1 Warmwasser-Total (thermisch, optional)
   hp2:
     heating_energy_total: 150.5     # Beispiel: HP2 verbrauchte bereits 150.5 kWh Heizung
     hot_water_energy_total: 45.25   # Beispiel: HP2 verbrauchte bereits 45.25 kWh Warmwasser
@@ -209,10 +209,12 @@ energy_consumption_offsets:
     defrost_energy_total: 150.0     # Alte Pumpe verbrauchte 150 kWh Abtau
 ```
 
-**Hinweis**: 
+**Hinweis**:
 - Alle Werte müssen in **kWh** angegeben werden
 - Verwenden Sie Punkt (.) als Dezimaltrennzeichen in YAML
 - Offsets werden nur auf TOTAL-Sensoren angewendet, nicht auf Daily/Monthly/Yearly Sensoren
+- Positive und **negative** Werte sind erlaubt. Ein negativer Offset subtrahiert den angegebenen Betrag vom Gesamtwert
+- Thermische Energie-Offsets (`{mode}_thermal_energy_total`) sind optional und gelten für Wärmeabgabe-Sensoren
 
 Weitere Informationen: [Historische Daten übernehmen](historische-daten.md)
 

--- a/docs/docs/Anwender/lambda-wp-config.md
+++ b/docs/docs/Anwender/lambda-wp-config.md
@@ -4,7 +4,7 @@ title: "lambda_wp_config.yaml Konfiguration"
 
 # lambda_wp_config.yaml Konfiguration
 
-*Zuletzt geändert am 21.03.2026*
+*Zuletzt geändert am 28.03.2026*
 
 Die `lambda_wp_config.yaml` Datei ist die Hauptkonfigurationsdatei für erweiterte Einstellungen der Lambda Heat Pumps Integration. Sie ermöglicht es, Sensoreinstellungen, Energieverbrauchserfassung und Modbus-Kommunikationsparameter anzupassen.
 
@@ -102,42 +102,19 @@ sensors_names_override:
 
 ### 3. Cycling-Zähler-Offsets
 
-Fügt Offsets zu Cycling-Zählern für Total-Sensoren hinzu. Nützlich beim Austausch von Wärmepumpen oder Zurücksetzen von Zählern.
+Fügt Offsets zu Cycling-Zählern für Total-Sensoren hinzu. Nützlich beim Austausch von Wärmepumpen, nach einem Zählerreset oder zur Korrektur eines falschen Ausgangswertes. Positive und **negative** Werte sind erlaubt.
 
 ```yaml
 cycling_offsets:
   hp1:
-    heating_cycling_total: 1500    # HP1 hatte bereits 1500 Heizungszyklen
-    hot_water_cycling_total: 800   # HP1 hatte bereits 800 Warmwasserzyklen
-    cooling_cycling_total: 200     # HP1 hatte bereits 200 Kühlungszyklen
-    defrost_cycling_total: 50      # HP1 hatte bereits 50 Abtauzyklen
-    compressor_start_cycling_total: 5000  # HP1 hatte bereits 5000 Kompressor-Starts
-  hp2:
-    heating_cycling_total: 0       # HP2 startet frisch
-    hot_water_cycling_total: 0     # HP2 startet frisch
-    cooling_cycling_total: 0       # HP2 startet frisch
-    defrost_cycling_total: 0       # HP2 startet frisch
-    compressor_start_cycling_total: 0     # HP2 startet frisch
+    heating_cycling_total: 1500
+    hot_water_cycling_total: 800
+    cooling_cycling_total: 200
+    defrost_cycling_total: 50
+    compressor_start_cycling_total: 5000
 ```
 
-**Wann verwenden?**
-- Wärmepumpen-Austausch: Zählerstand der vorherigen Pumpe hinzufügen
-- Zähler-Reset: Manuelle Resets kompensieren
-- Historische Daten erhalten: Kontinuität der Daten beibehalten
-
-**Hinweis:** Positive und **negative** Werte sind erlaubt. Ein negativer Offset subtrahiert den angegebenen Betrag vom Gesamtzähler (z. B. um einen zu hohen Ausgangswert zu korrigieren).
-
-**Beispiel-Szenario: Wärmepumpen-Austausch**
-```yaml
-cycling_offsets:
-  hp1:
-    heating_cycling_total: 2500    # Alte Pumpe hatte 2500 Heizungszyklen
-    hot_water_cycling_total: 1200  # Alte Pumpe hatte 1200 Warmwasserzyklen
-    cooling_cycling_total: 300     # Alte Pumpe hatte 300 Kühlungszyklen
-    defrost_cycling_total: 80      # Alte Pumpe hatte 80 Abtauzyklen
-```
-
-Weitere Informationen: [Historische Daten übernehmen](historische-daten.md)
+Ausführliche Beschreibung, alle Szenarien und negative Offsets: [Offsets – Historische Daten übernehmen](offsets.md)
 
 ### 4. Energieverbrauchs-Sensoren
 
@@ -176,49 +153,24 @@ Weitere Informationen: [Energieverbrauchsberechnung](Energieverbrauchsberechnung
 
 ### 5. Energieverbrauchs-Offsets
 
-Fügt Offsets zu Energieverbrauchswerten für Total-Sensoren hinzu. Nützlich beim Austausch von Wärmepumpen oder Zurücksetzen von Zählern.
+Fügt Offsets zu Energieverbrauchswerten für Total-Sensoren hinzu. Nützlich beim Austausch von Wärmepumpen, nach einem Zählerreset oder zur Korrektur eines falschen Ausgangswertes.
 
-**⚠️ WICHTIG: Alle Werte müssen in kWh angegeben werden!**
+**⚠️ WICHTIG: Alle Werte müssen in kWh angegeben werden!** Positive und **negative** Werte sind erlaubt.
 
 ```yaml
 energy_consumption_offsets:
   hp1:
-    heating_energy_total: 0.0            # kWh Offset für HP1 Heizungs-Total (elektrisch)
-    hot_water_energy_total: 0.0          # kWh Offset für HP1 Warmwasser-Total (elektrisch)
-    cooling_energy_total: 0.0            # kWh Offset für HP1 Kühlungs-Total (elektrisch)
-    defrost_energy_total: 0.0            # kWh Offset für HP1 Abtau-Total (elektrisch)
-    heating_thermal_energy_total: 0.0    # kWh Offset für HP1 Heizungs-Total (thermisch, optional)
-    hot_water_thermal_energy_total: 0.0  # kWh Offset für HP1 Warmwasser-Total (thermisch, optional)
-  hp2:
-    heating_energy_total: 150.5     # Beispiel: HP2 verbrauchte bereits 150.5 kWh Heizung
-    hot_water_energy_total: 45.25   # Beispiel: HP2 verbrauchte bereits 45.25 kWh Warmwasser
-    cooling_energy_total: 12.8      # Beispiel: HP2 verbrauchte bereits 12.8 kWh Kühlung
-    defrost_energy_total: 3.1       # Beispiel: HP2 verbrauchte bereits 3.1 kWh Abtau
+    heating_energy_total: 5000.0              # kWh elektrisch
+    hot_water_energy_total: 2000.0
+    cooling_energy_total: 500.0
+    defrost_energy_total: 150.0
+    heating_thermal_energy_total: 18000.0     # kWh thermisch (optional)
+    hot_water_thermal_energy_total: 7200.0
+    cooling_thermal_energy_total: 1500.0
+    defrost_thermal_energy_total: 480.0
 ```
 
-**Wann verwenden?**
-- Wärmepumpen-Austausch: Energieverbrauch der vorherigen Pumpe hinzufügen
-- Zähler-Reset: Manuelle Resets kompensieren
-- Historische Daten erhalten: Energieverbrauchshistorie beibehalten
-
-**Beispiel-Szenario: Wärmepumpen-Austausch**
-```yaml
-energy_consumption_offsets:
-  hp1:
-    heating_energy_total: 5000.0    # Alte Pumpe verbrauchte 5000 kWh Heizung
-    hot_water_energy_total: 2000.0  # Alte Pumpe verbrauchte 2000 kWh Warmwasser
-    cooling_energy_total: 500.0     # Alte Pumpe verbrauchte 500 kWh Kühlung
-    defrost_energy_total: 150.0     # Alte Pumpe verbrauchte 150 kWh Abtau
-```
-
-**Hinweis**:
-- Alle Werte müssen in **kWh** angegeben werden
-- Verwenden Sie Punkt (.) als Dezimaltrennzeichen in YAML
-- Offsets werden nur auf TOTAL-Sensoren angewendet, nicht auf Daily/Monthly/Yearly Sensoren
-- Positive und **negative** Werte sind erlaubt. Ein negativer Offset subtrahiert den angegebenen Betrag vom Gesamtwert
-- Thermische Energie-Offsets (`{mode}_thermal_energy_total`) sind optional und gelten für Wärmeabgabe-Sensoren
-
-Weitere Informationen: [Historische Daten übernehmen](historische-daten.md)
+Ausführliche Beschreibung, alle Szenarien, thermische Offsets und negative Offsets: [Offsets – Historische Daten übernehmen](offsets.md)
 
 ### 6. Modbus-Konfiguration
 

--- a/docs/docs/Anwender/lambda-wp-config.md
+++ b/docs/docs/Anwender/lambda-wp-config.md
@@ -4,6 +4,8 @@ title: "lambda_wp_config.yaml Konfiguration"
 
 # lambda_wp_config.yaml Konfiguration
 
+*Zuletzt geändert am 21.03.2026*
+
 Die `lambda_wp_config.yaml` Datei ist die Hauptkonfigurationsdatei für erweiterte Einstellungen der Lambda Heat Pumps Integration. Sie ermöglicht es, Sensoreinstellungen, Energieverbrauchserfassung und Modbus-Kommunikationsparameter anzupassen.
 
 ## Datei-Location

--- a/docs/docs/Anwender/offsets.md
+++ b/docs/docs/Anwender/offsets.md
@@ -1,0 +1,279 @@
+---
+title: "Offsets – Historische Daten übernehmen"
+---
+
+# Offsets – Historische Daten übernehmen
+
+*Zuletzt geändert am 28.03.2026*
+
+Offsets ermöglichen es, historische Zähler- und Verbrauchswerte nahtlos fortzuführen – etwa nach dem Austausch einer Wärmepumpe, nach einem Zählerreset oder zur Korrektur eines falschen Ausgangswertes. Die Integration unterstützt zwei unabhängige Offset-Typen:
+
+| Typ | Sensoren | Einheit | YAML-Schlüssel |
+|-----|----------|---------|----------------|
+| **Cycling-Offsets** | Betriebszyklenzähler | Zyklen (Integer) | `cycling_offsets` |
+| **Energie-Offsets** | Energieverbrauchs-Totals | kWh (Float) | `energy_consumption_offsets` |
+
+Beide Typen werden in der Datei `/config/lambda_wp_config.yaml` konfiguriert (→ [Konfigurationsübersicht](lambda-wp-config.md)).
+
+---
+
+## Wie funktionieren Offsets?
+
+### Differenz-Tracking – kein Doppelzählen
+
+Offsets werden **nicht blind addiert**, sondern es wird immer nur die **Differenz** zum bereits angewendeten Offset berechnet. Das System speichert jeden angewendeten Offset als Attribut `applied_offset` im HA-State.
+
+**Beispiel: Cycling-Offset = 1500**
+
+| Ereignis | Sensorwert | `applied_offset` | Differenz |
+|----------|----------:|------------------:|----------:|
+| Erststart, Offset = 1500 | 0 → **1500** | 0 → 1500 | +1500 |
+| HA-Neustart, Offset unverändert | 1500 (restored) | 1500 (restored) | 0 – kein Effekt |
+| Offset auf 1600 geändert | 1500 → **1600** | 1500 → 1600 | +100 |
+
+So ist es **sicher, Home Assistant beliebig oft neu zu starten** – der Offset wird nie doppelt angewendet.
+
+### Wann werden Offsets angewendet?
+
+Offsets werden **einmalig beim HA-Start** angewendet, sobald der Sensor initialisiert wird. Im laufenden Betrieb werden nur tatsächliche Zählinkremente addiert – der Offset hat keinen Einfluss mehr.
+
+### Negative Offsets – Korrektur eines zu hohen Wertes
+
+**Positive und negative Werte sind ausdrücklich erlaubt.** Ein negativer Offset subtrahiert den angegebenen Betrag vom Gesamtzähler und ermöglicht so die Korrektur eines falschen Ausgangswertes:
+
+```yaml
+cycling_offsets:
+  hp1:
+    heating_cycling_total: -200   # Subtrahiert 200 von der Gesamtzahl
+```
+
+```yaml
+energy_consumption_offsets:
+  hp1:
+    heating_energy_total: -150.5  # Subtrahiert 150,5 kWh vom Total
+```
+
+---
+
+## 1. Cycling-Offsets
+
+### Welche Sensoren?
+
+Cycling-Offsets wirken ausschließlich auf **Total-Sensoren** (`*_cycling_total`). Daily-, Monthly- und Yearly-Sensoren erhalten keine Offsets.
+
+| YAML-Schlüssel | Beschreibung |
+|----------------|-------------|
+| `heating_cycling_total` | Gesamtzahl Heizzyklen |
+| `hot_water_cycling_total` | Gesamtzahl Warmwasserzyklen |
+| `cooling_cycling_total` | Gesamtzahl Kühlzyklen |
+| `defrost_cycling_total` | Gesamtzahl Abtauzyklen |
+| `compressor_start_cycling_total` | Gesamtzahl Kompressorstarts |
+
+### Konfiguration
+
+```yaml
+cycling_offsets:
+  hp1:
+    heating_cycling_total: 1500             # HP1 hatte bereits 1500 Heizzyklen
+    hot_water_cycling_total: 800            # HP1 hatte bereits 800 Warmwasserzyklen
+    cooling_cycling_total: 200              # HP1 hatte bereits 200 Kühlzyklen
+    defrost_cycling_total: 50               # HP1 hatte bereits 50 Abtauzyklen
+    compressor_start_cycling_total: 5000    # HP1 hatte bereits 5000 Kompressorstarts
+  hp2:
+    heating_cycling_total: 0
+    hot_water_cycling_total: 0
+    cooling_cycling_total: 0
+    defrost_cycling_total: 0
+    compressor_start_cycling_total: 0
+```
+
+### Typische Szenarien
+
+#### Szenario A: Wärmepumpen-Austausch
+
+Alte Pumpe hatte 2500 Heizzyklen. Neue Pumpe startet bei 0, der Zähler in HA soll trotzdem weiterlaufen:
+
+```yaml
+cycling_offsets:
+  hp1:
+    heating_cycling_total: 2500
+    hot_water_cycling_total: 1200
+    cooling_cycling_total: 300
+    defrost_cycling_total: 80
+    compressor_start_cycling_total: 12000
+```
+
+#### Szenario B: Manueller Zähler-Reset
+
+Der Modbus-Zähler der Wärmepumpe wurde zurückgesetzt, der HA-Gesamtzähler soll nicht zurückspringen:
+
+```yaml
+cycling_offsets:
+  hp1:
+    heating_cycling_total: 5000   # Wert vor dem Reset
+```
+
+#### Szenario C: Falscher Ausgangswert korrigieren
+
+Ein fehlerhafter Offset hat den Zähler um 500 zu hoch gesetzt:
+
+```yaml
+cycling_offsets:
+  hp1:
+    heating_cycling_total: -500   # Subtrahiert 500 vom Gesamtzähler
+```
+
+---
+
+## 2. Energie-Offsets
+
+### Welche Sensoren?
+
+Energie-Offsets wirken ausschließlich auf **Total-Sensoren** (`*_energy_total`). Es gibt zwei Untertypen:
+
+**Elektrische Offsets** (`{mode}_energy_total`):
+
+| YAML-Schlüssel | Beschreibung |
+|----------------|-------------|
+| `heating_energy_total` | Elektrischer Gesamtverbrauch Heizen |
+| `hot_water_energy_total` | Elektrischer Gesamtverbrauch Warmwasser |
+| `cooling_energy_total` | Elektrischer Gesamtverbrauch Kühlen |
+| `defrost_energy_total` | Elektrischer Gesamtverbrauch Abtauen |
+
+**Thermische Offsets** (`{mode}_thermal_energy_total`, optional):
+
+| YAML-Schlüssel | Beschreibung |
+|----------------|-------------|
+| `heating_thermal_energy_total` | Thermischer Gesamtoutput Heizen |
+| `hot_water_thermal_energy_total` | Thermischer Gesamtoutput Warmwasser |
+| `cooling_thermal_energy_total` | Thermischer Gesamtoutput Kühlen |
+| `defrost_thermal_energy_total` | Thermischer Gesamtoutput Abtauen |
+
+### Konfiguration
+
+**⚠️ Alle Werte müssen in kWh angegeben werden! Dezimaltrennzeichen: Punkt (`.`)**
+
+```yaml
+energy_consumption_offsets:
+  hp1:
+    # Elektrische Offsets (Stromverbrauch):
+    heating_energy_total: 5000.0              # kWh, HP1 hatte bereits 5000 kWh Heizen
+    hot_water_energy_total: 2000.0            # kWh, HP1 hatte bereits 2000 kWh Warmwasser
+    cooling_energy_total: 500.0               # kWh
+    defrost_energy_total: 150.0               # kWh
+    # Thermische Offsets (Wärmeabgabe, optional):
+    heating_thermal_energy_total: 18000.0     # kWh thermischer Output Heizen
+    hot_water_thermal_energy_total: 7200.0    # kWh thermischer Output Warmwasser
+    cooling_thermal_energy_total: 1500.0      # kWh
+    defrost_thermal_energy_total: 480.0       # kWh
+  hp2:
+    heating_energy_total: 150.5
+    hot_water_energy_total: 45.25
+    cooling_energy_total: 12.8
+    defrost_energy_total: 3.1
+```
+
+### Wh vs. kWh
+
+Die Quellsensoren (→ [Energieverbrauchsberechnung](Energieverbrauchsberechnung.md)) können Wh oder kWh liefern – die Konvertierung erfolgt automatisch. **Offset-Werte** müssen jedoch immer in **kWh** angegeben werden.
+
+| Quellsensor | Offset |
+|-------------|--------|
+| Wh → automatische Konvertierung | Immer kWh |
+
+### Typische Szenarien
+
+#### Szenario A: Wärmepumpen-Austausch
+
+```yaml
+energy_consumption_offsets:
+  hp1:
+    heating_energy_total: 5000.0
+    hot_water_energy_total: 2000.0
+    cooling_energy_total: 500.0
+    defrost_energy_total: 150.0
+    heating_thermal_energy_total: 18000.0
+    hot_water_thermal_energy_total: 7200.0
+```
+
+#### Szenario B: Zähler-Reset kompensieren
+
+```yaml
+energy_consumption_offsets:
+  hp1:
+    heating_energy_total: 10000.5   # Gesamtwert vor dem Reset
+    hot_water_energy_total: 3500.25
+```
+
+#### Szenario C: Korrektur eines zu hohen Wertes
+
+```yaml
+energy_consumption_offsets:
+  hp1:
+    heating_energy_total: -250.0   # Subtrahiert 250 kWh vom Total
+```
+
+---
+
+## Schritt-für-Schritt: Offsets einrichten
+
+### Schritt 1: Werte ermitteln
+
+Notieren Sie die letzten bekannten Zählerstände der alten oder zurückgesetzten Wärmepumpe:
+- Cycling-Zähler: z. B. aus dem HA-Verlauf oder aus der Wärmepumpen-Steuerung
+- Energie-Totals: aus dem letzten bekannten HA-Sensorwert (in kWh)
+
+### Schritt 2: lambda_wp_config.yaml bearbeiten
+
+Öffnen Sie `/config/lambda_wp_config.yaml` (→ [Konfigurationsanleitung](lambda-wp-config.md)) und fügen Sie die Offset-Abschnitte hinzu:
+
+```yaml
+cycling_offsets:
+  hp1:
+    heating_cycling_total: 2500
+    # weitere Schlüssel ...
+
+energy_consumption_offsets:
+  hp1:
+    heating_energy_total: 5000.0
+    # weitere Schlüssel ...
+```
+
+### Schritt 3: Home Assistant neu starten
+
+Nach dem Speichern muss Home Assistant vollständig neu gestartet werden. Die Offsets werden beim nächsten Start automatisch auf die Total-Sensoren angewendet.
+
+### Schritt 4: Überprüfen
+
+Prüfen Sie, ob die Sensor-Werte korrekt sind:
+- Die Total-Sensoren sollten den Basiswert + Offset zeigen
+- Das Attribut `applied_offset` am Sensor zeigt den aktuell angewendeten Offset
+
+---
+
+## Häufige Probleme
+
+### Offset wird nicht angewendet
+
+- YAML-Syntax prüfen (Einrückung mit Leerzeichen, kein Tab)
+- Sicherstellen, dass HA vollständig neu gestartet wurde
+- HA-Logs auf Fehlermeldungen prüfen
+
+### Energie-Offset in falscher Einheit
+
+- Alle Energie-Offsets müssen in **kWh** angegeben werden
+- Umrechnung: Wh ÷ 1000 = kWh
+
+### Offset wurde doppelt angewendet
+
+- Das sollte durch das Differenz-Tracking nicht passieren
+- Wenn doch: Den Wert des Attributs `applied_offset` des betroffenen Sensors prüfen
+- Im Log nachsehen, ob der Offset korrekt protokolliert wurde
+
+---
+
+## Verwandte Seiten
+
+- [lambda_wp_config.yaml Konfiguration](lambda-wp-config.md) – vollständige Konfigurationsdatei
+- [Energieverbrauchsberechnung](Energieverbrauchsberechnung.md) – Quellsensoren für Energiedaten
+- [Historische Daten löschen](historische_daten_loeschen.md) – Zähler und Verlauf zurücksetzen

--- a/docs/docs/Anwender/optionen-config-flow.md
+++ b/docs/docs/Anwender/optionen-config-flow.md
@@ -4,6 +4,8 @@ title: "Optionen des config_flow"
 
 # Optionen des config_flow
 
+*Zuletzt geändert am 21.03.2026*
+
 <div style="display: flex; gap: 20px; align-items: flex-start; margin: 20px 0; flex-wrap: wrap;">
   <div style="flex: 0 0 50%; min-width: 300px;">
     <img src="../../assets/config_flow_options_de.png" alt="Config Flow Optionen" style="width: 100%; height: auto; border-radius: 8px;">

--- a/docs/docs/Anwender/pv_ueberschuss_steuerung.md
+++ b/docs/docs/Anwender/pv_ueberschuss_steuerung.md
@@ -4,6 +4,8 @@ title: "PV Überschuss Steuerung"
 
 # PV Überschuss Steuerung
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda kann ihre Leistung erhöhen, wenn PV-Überschuss vorliegt. 
 
 Diese Integration unterstützt die Funktion, die Option muss in der Configuration der Lambda Wärmepumpen Integration aktiviert und konfiguriert werden. 

--- a/docs/docs/Anwender/raumthermometer.md
+++ b/docs/docs/Anwender/raumthermometer.md
@@ -4,6 +4,8 @@ title: "Raumthermometer"
 
 # Raumthermometer
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda Heat Pumps Integration unterstützt die Integration externer Raumthermometer-Sensoren für eine präzise Temperatursteuerung. Diese Funktion ermöglicht es, die Heizkurven-Vorlauftemperatur basierend auf der tatsächlichen Raumtemperatur anzupassen.
 
 ## Übersicht

--- a/docs/docs/Anwender/warmwasser-solltemperatur.md
+++ b/docs/docs/Anwender/warmwasser-solltemperatur.md
@@ -4,6 +4,8 @@ title: "Warmwasser Solltemperatur Steuerung"
 
 # Warmwasser Solltemperatur Steuerung
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda Heat Pumps Integration ermöglicht die Steuerung der Warmwasser-Solltemperatur über Home Assistant. Sie können die gewünschte Warmwassertemperatur direkt in Home Assistant einstellen, und die Integration schreibt diese Werte an die Lambda-Wärmepumpe.
 
 ## Verfügbare Entitäten

--- a/docs/docs/Entwickler/Ablaufdiagramm.md
+++ b/docs/docs/Entwickler/Ablaufdiagramm.md
@@ -1,6 +1,8 @@
 # Lambda Heat Pumps Integration – Ablaufdiagramm & Entwicklerreferenz
 
-**Stand:** Release 2.3 · **Letzte Aktualisierung:** 2026-02-21
+*Zuletzt geändert am 21.03.2026*
+
+**Stand:** Release 2.4.0 · **Letzte Aktualisierung:** 2026-03-21
 
 Dieses Dokument beschreibt den vollständigen Ablauf der Integration – von der Initialisierung bis zum laufenden Betrieb. Es dient als Referenz für zukünftige Entwicklung und Debugging.
 

--- a/docs/docs/Entwickler/cop-sensoren.md
+++ b/docs/docs/Entwickler/cop-sensoren.md
@@ -4,6 +4,8 @@ title: "COP-Sensoren - Technische Dokumentation"
 
 # COP-Sensoren - Technische Dokumentation
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Dokumentation beschreibt die technische Implementierung der COP-Sensoren (Coefficient of Performance) in der Lambda Heat Pumps Integration.
 
 ## Übersicht

--- a/docs/docs/Entwickler/cycling-sensoren.md
+++ b/docs/docs/Entwickler/cycling-sensoren.md
@@ -224,7 +224,6 @@ if (self._initialization_complete and
         hp_index=hp_idx,
         name_prefix=self.entry.data.get("name", "eu08l"),
         use_legacy_modbus_names=self._use_legacy_names,
-        cycling_offsets=self._cycling_offsets,
     )
 
 # _last_operating_state wird NACH der Verarbeitung aktualisiert
@@ -250,60 +249,51 @@ async def increment_cycling_counter(
     hp_index: int,
     name_prefix: str,
     use_legacy_modbus_names: bool = True,
-    cycling_offsets: dict = None,
 ):
     """
     Increment ALL cycling counters for a given mode and heat pump index.
     This should be called only on a real flank (state change)!
-    
+
     Increments: Total, Daily, 2H, 4H sensors
     """
     device_prefix = f"hp{hp_index}"
-    
+
     # Liste aller Sensor-Typen, die erhöht werden sollen
     sensor_types = [
         f"{mode}_cycling_total",
-        f"{mode}_cycling_daily", 
+        f"{mode}_cycling_daily",
         f"{mode}_cycling_2h",
         f"{mode}_cycling_4h"
     ]
-    
+
     # Für compressor_start: auch monthly hinzufügen
     if mode == "compressor_start":
         sensor_types.append(f"{mode}_cycling_monthly")
-    
+
     for sensor_id in sensor_types:
         # Finde Entity
         names = generate_sensor_names(...)
         entity_id = names["entity_id"]
-        
+
         # Hole aktuellen Wert
         state_obj = hass.states.get(entity_id)
         current = int(float(state_obj.state)) if state_obj else 0
-        
-        # Offset nur für Total-Sensoren anwenden
-        offset = 0
-        if cycling_offsets is not None and sensor_id.endswith("_total"):
-            device_key = device_prefix
-            if device_key in cycling_offsets:
-                offset = int(cycling_offsets[device_key].get(sensor_id, 0))
-        
-        # Erhöhe um 1
+
+        # Erhöhe um 1 – kein Offset hier
         new_value = int(current + 1)
-        final_value = int(new_value + offset)
-        
+
         # Setze neuen Wert
         cycling_entity = find_cycling_entity(hass, entity_id)
         if cycling_entity:
-            cycling_entity.set_cycling_value(final_value)
+            cycling_entity.set_cycling_value(new_value)
         else:
             # Fallback: State setzen
-            hass.states.async_set(entity_id, final_value, ...)
+            hass.states.async_set(entity_id, new_value, ...)
 ```
 
-**Wichtig**: 
+**Wichtig**:
 - Alle Perioden (Total, Daily, 2h, 4h) werden gleichzeitig um +1 erhöht
-- Offsets werden nur für Total-Sensoren angewendet
+- **Kein Offset in dieser Funktion** — Offsets werden ausschließlich durch `_apply_cycling_offset()` in `sensor.py` beim Start angewendet
 - Die Funktion sollte nur bei echten Flanken (State Changes) aufgerufen werden
 
 ### 5. LambdaCyclingSensor Klasse
@@ -452,11 +442,11 @@ Cycling-Offsets werden in `lambda_wp_config.yaml` konfiguriert:
 ```yaml
 cycling_offsets:
   hp1:
-    heating_cycling_total: 100
-    hot_water_cycling_total: 50
+    heating_cycling_total: 1500    # Positive Werte addieren
+    hot_water_cycling_total: -50   # Negative Werte subtrahieren (z. B. zur Korrektur)
 ```
 
-Offsets werden nur für Total-Sensoren angewendet:
+Offsets werden **ausschließlich** durch `_apply_cycling_offset()` in `sensor.py` angewendet — einmalig beim Start jedes Total-Sensors:
 
 ```python
 # In LambdaCyclingSensor._apply_cycling_offset()
@@ -464,14 +454,14 @@ async def _apply_cycling_offset(self):
     """Apply cycling offset from configuration."""
     config = await load_lambda_config(self.hass)
     cycling_offsets = config.get("cycling_offsets", {})
-    
+
     device_key = f"hp{self._hp_index}"
     current_offset = cycling_offsets[device_key].get(self._sensor_id, 0)
     applied_offset = getattr(self, "_applied_offset", 0)
-    
-    # Berechne Differenz
+
+    # Berechne Differenz zwischen konfiguriertem und bereits angewendetem Offset
     offset_difference = current_offset - applied_offset
-    
+
     if offset_difference != 0:
         old_value = self._cycling_value
         self._cycling_value = int(self._cycling_value + offset_difference)
@@ -479,11 +469,14 @@ async def _apply_cycling_offset(self):
         self.async_write_ha_state()
 ```
 
+**`increment_cycling_counter()` kennt keinen Offset** — das war ein früherer Bug (B-1), der dazu führte, dass der volle YAML-Offset bei jedem Zyklus-Ereignis erneut addiert wurde. Nach dem Fix liegt die alleinige Verantwortung bei `_apply_cycling_offset()`.
+
 **Wichtig**:
-- Offsets werden nur beim Start angewendet (in `restore_state()`)
+- Offsets werden nur beim HA-Start angewendet (in `async_added_to_hass()` → `_apply_cycling_offset()`)
 - Nur Total-Sensoren unterstützen Offsets
-- Der angewendete Offset wird in `_applied_offset` gespeichert
-- Bei Änderung des Offsets wird die Differenz zum aktuellen Wert addiert
+- Der angewendete Offset wird in `_applied_offset` gespeichert und über `applied_offset`-Attribut persistiert
+- Bei YAML-Änderung wird nach Neustart nur die **Differenz** zum bisher angewendeten Wert addiert — keine Doppelanwendung
+- Positive und **negative** Offsets sind erlaubt
 
 ### 9. Persistenz
 
@@ -645,7 +638,7 @@ MODES = {
 Cycling-Sensoren verwenden strukturiertes Logging:
 
 ```python
-_LOGGER.info(f"Cycling counter incremented: {entity_id} = {final_value} (was {current}, offset {offset})")
+_LOGGER.info(f"Cycling counter incremented: {entity_id} = {new_value} (was {current}) [entity updated]")
 _LOGGER.debug(f"Cycling sensor {entity_id} value set to {value}")
 _LOGGER.warning(f"Cycling entity {entity_id} not found, using fallback state update")
 ```

--- a/docs/docs/Entwickler/cycling-sensoren.md
+++ b/docs/docs/Entwickler/cycling-sensoren.md
@@ -4,6 +4,8 @@ title: "Cycling-Sensoren - Technische Dokumentation"
 
 # Cycling-Sensoren - Technische Dokumentation
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Dokumentation beschreibt die technische Implementierung der Cycling-Sensoren in der Lambda Heat Pumps Integration.
 
 ## Übersicht

--- a/docs/docs/Entwickler/energieverbrauchssensoren.md
+++ b/docs/docs/Entwickler/energieverbrauchssensoren.md
@@ -4,6 +4,8 @@ title: "Energieverbrauchssensoren - Technische Dokumentation"
 
 # Energieverbrauchssensoren - Technische Dokumentation
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Dokumentation beschreibt die technische Implementierung der Energieverbrauchssensoren (elektrisch und thermisch) in der Lambda Heat Pumps Integration.
 
 ## Übersicht

--- a/docs/docs/Entwickler/entity-duplikat-cleanup.md
+++ b/docs/docs/Entwickler/entity-duplikat-cleanup.md
@@ -4,6 +4,8 @@ title: "Entity-Duplikate (_2, _3) – Cleanup"
 
 # Entity-Duplikate (_2, _3) – Cleanup
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Seite beschreibt, wie die Integration doppelt angelegte Entities (z. B. `sensor.xyz_2`, `climate.xyz_3`) erkennt und bereinigt – ohne die Namenslogik oder bestehende Entity-IDs zu ändern (kein Verlust historischer Daten).
 
 ## Hintergrund

--- a/docs/docs/Entwickler/features.md
+++ b/docs/docs/Entwickler/features.md
@@ -4,6 +4,8 @@ title: "Features (Technische Übersicht)"
 
 # Features – Technische Übersicht
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Seite bietet eine technische Übersicht der wichtigsten Features der Lambda Heat Pumps Integration mit Code-Beispielen und Implementierungsdetails.
 
 ## Architektur-Übersicht

--- a/docs/docs/Entwickler/firmware-einstellung-auswirkungen.md
+++ b/docs/docs/Entwickler/firmware-einstellung-auswirkungen.md
@@ -4,6 +4,8 @@ title: "Firmware-Einstellung – technische Auswirkungen"
 
 # Firmware-Einstellung – technische Auswirkungen
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Seite beschreibt, wo die Firmware-Version in der Integration gesetzt wird, wie sie ausgewertet wird und welche Folgen die **initiale Konfiguration** gegenüber einer **späteren Änderung** der Firmware haben.
 
 ## Speicherort der Firmware-Version

--- a/docs/docs/Entwickler/heizkurve.md
+++ b/docs/docs/Entwickler/heizkurve.md
@@ -4,6 +4,8 @@ title: "Heizkurve"
 
 # Heizkurve
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Lambda Heat Pumps Integration unterstützt die Konfiguration von Heizkurven für jeden Heizkreis. Die Heizkurve bestimmt die Vorlauftemperatur basierend auf der Außentemperatur und ermöglicht eine energieeffiziente und komfortable Heizungssteuerung.
 
 ## Übersicht

--- a/docs/docs/Entwickler/index.md
+++ b/docs/docs/Entwickler/index.md
@@ -2,4 +2,6 @@
 title: "Entwickler Doku"
 ---
 
+*Zuletzt geändert am 21.03.2026*
+
 Hier entsteht so nach und nach die Entwicklerdokumentation

--- a/docs/docs/Entwickler/installation.md
+++ b/docs/docs/Entwickler/installation.md
@@ -4,6 +4,8 @@ title: "Manuelle Installation"
 
 # Manuelle Installation
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Anleitung beschreibt, wie Sie die Lambda Heat Pumps Integration manuell ohne HACS installieren können.
 
 !!! tip "Einfachere Installation mit HACS"

--- a/docs/docs/Entwickler/migration-system.md
+++ b/docs/docs/Entwickler/migration-system.md
@@ -1,0 +1,283 @@
+---
+title: "Migrationssystem"
+---
+
+# Migrationssystem
+
+*Zuletzt geändert am 28.03.2026*
+
+Das Migrationssystem der Lambda Heat Pumps Integration sorgt dafür, dass bestehende Installationen bei einem Update automatisch und sicher auf den neuesten Stand gebracht werden – ohne manuellen Eingriff und ohne Datenverlust.
+
+---
+
+## Übersicht
+
+Das System besteht aus zwei Schichten:
+
+| Schicht | Datei | Zweck |
+|---------|-------|-------|
+| Versionierte Migrationen | `migration.py` | Einmalige, versionsgebundene Änderungen (Entity-Registry, Config-Entry-Daten) |
+| Config-Datei-Migration | `migration.py` → `migrate_lambda_config_sections()` | Laufende Pflege der `lambda_wp_config.yaml` (neue Abschnitte, neue Schlüssel) |
+| Konstanten | `const_migration.py` | Versionsnummern, Timeouts, Backup-Parameter, Standardwerte |
+
+---
+
+## Versionsverwaltung (`MigrationVersion`)
+
+Jede strukturelle Änderung erhält eine eigene Versionsnummer in der `MigrationVersion`-Enum (`const_migration.py`):
+
+```python
+class MigrationVersion(IntEnum):
+    INITIAL                   = 1   # Ursprüngliche Version
+    LEGACY_NAMES              = 2   # Entity-Namen Migration
+    CYCLING_OFFSETS           = 3   # lambda_wp_config.yaml: cycling_offsets
+    ENERGY_CONSUMPTION        = 4   # energy_consumption_sensors & offsets
+    ENTITY_OPTIMIZATION       = 5   # Entity-Struktur optimieren
+    CONFIG_RESTRUCTURE        = 6   # Konfigurationsschema
+    UNIFIED_CONFIG_MIGRATION  = 7   # Template-basierte Migration aller Abschnitte
+    REGISTER_ORDER_TERMINOLOGY = 8  # int32_byte_order → int32_register_order
+```
+
+Die aktuelle Version wird automatisch aus dem höchsten Wert ermittelt:
+
+```python
+MIGRATION_VERSION = MigrationVersion.get_latest().value  # = 8
+```
+
+Beim Setup einer neuen Installation wird diese Versionsnummer im Config-Entry gespeichert. Beim Start prüft die Integration, ob die gespeicherte Version kleiner als `MIGRATION_VERSION` ist, und führt alle ausstehenden Migrationen in Reihenfolge aus.
+
+---
+
+## Ablauf beim HA-Start
+
+```
+HA-Start
+  └── async_setup_entry()
+        ├── Versionsvergleich: config_entry.version vs. MIGRATION_VERSION
+        │     └── falls veraltet: async_migrate_entry() → versionierte Migrationen
+        └── load_lambda_config()
+              ├── ensure_lambda_config()        (Datei anlegen falls nicht vorhanden)
+              └── migrate_lambda_config_sections()  (Config-Datei pflegen, einmal pro Session)
+```
+
+Der Flag `hass.data["_lambda_migration_done"]` verhindert, dass `migrate_lambda_config_sections()` innerhalb einer HA-Session mehrfach ausgeführt wird.
+
+---
+
+## Config-Datei-Migration (`migrate_lambda_config_sections`)
+
+Diese Funktion läuft bei **jedem HA-Start** (einmal pro Session) und prüft die `lambda_wp_config.yaml` auf fehlende oder veraltete Inhalte. Sie arbeitet rein textbasiert, um Kommentare und Formatierung zu erhalten.
+
+### Ablauf im Detail
+
+```
+1. Datei einlesen (UTF-8)
+2. YAML parsen → current_config
+3. Schritt A: energy_consumption_sensors-Format upgrade
+4. Schritt B: thermal_sensor_entity_id-Zeilen ergänzen
+5. Schritt C: compressor_start_cycling_total ergänzen     ← V2.4.0
+6. Abschnitte mit _find_section_ranges_in_content() lokalisieren
+7. Fehlende Abschnitte (aus Template) an korrekter Position einfügen
+8. Backup anlegen → Datei schreiben
+```
+
+### Schritt A – energy_consumption_sensors Formatupgrade
+
+Ältere Installationen enthielten einen veralteten Kommentar-Header ohne den Hinweis auf `thermal_sensor_entity_id`. Die Migration ersetzt den alten Header durch den neuen:
+
+```yaml
+# Alter Header (wird ersetzt):
+# Das System konvertiert automatisch zu kWh für die Berechnungen
+# Beispiel:
+energy_consumption_sensors:
+
+# Neuer Header (nach Migration):
+# Das System konvertiert automatisch zu kWh für die Berechnungen
+# sensor_entity_id = elektrisch, thermal_sensor_entity_id = thermisch (optional)
+# Beispiel:
+energy_consumption_sensors:
+```
+
+### Schritt B – `thermal_sensor_entity_id` ergänzen
+
+Nach jeder `sensor_entity_id:`-Zeile im `energy_consumption_sensors`-Block wird geprüft, ob die Folgezeile bereits `thermal_sensor_entity_id:` enthält. Falls nicht, wird die optionale Kommentarzeile eingefügt – mit identischem Einrückungs-Präfix (auch für auskommentierte `#  hp2`-Blöcke):
+
+```yaml
+# Vorher:
+  hp1:
+    sensor_entity_id: "sensor.lambda_wp_verbrauch"
+
+# Nachher:
+  hp1:
+    sensor_entity_id: "sensor.lambda_wp_verbrauch"
+    # thermal_sensor_entity_id: "sensor.lambda_wp_waerme"  # optional
+```
+
+### Schritt C – `compressor_start_cycling_total` ergänzen (V2.4.0)
+
+Nach jeder `defrost_cycling_total:`-Zeile im `cycling_offsets`-Block wird geprüft, ob die Folgezeile bereits `compressor_start_cycling_total:` enthält. Falls nicht, wird die Zeile eingefügt. Das Präfix (Kommentarzeichen `#` und Einrückung) wird aus der `defrost_cycling_total:`-Zeile übernommen – korrekt für auskommentierte Beispiele und aktive Konfigurationen:
+
+```yaml
+# Vorher (auskommentiert):
+#    defrost_cycling_total: 0      # Offset for HP1 defrost total cycles
+
+# Nachher:
+#    defrost_cycling_total: 0      # Offset for HP1 defrost total cycles
+#    compressor_start_cycling_total: 0      # Offset for compressor start total
+```
+
+```yaml
+# Vorher (aktiv):
+    defrost_cycling_total: 5
+
+# Nachher:
+    defrost_cycling_total: 5
+    compressor_start_cycling_total: 0      # Offset for compressor start total
+```
+
+### Schritt D – Fehlende Abschnitte einfügen
+
+Die fünf Template-Abschnitte werden anhand ihrer eindeutigen Header-Zeilen in der Datei gesucht:
+
+| Abschnitt | Header-Zeile |
+|-----------|-------------|
+| `sensors_names_override` | `# Override sensor names (only works if use_legacy_modbus_names is true)` |
+| `cycling_offsets` | `# Cycling counter offsets for total sensors` |
+| `energy_consumption_sensors` | `# Energy consumption sensor configuration` |
+| `energy_consumption_offsets` | `# Energy consumption offsets for total sensors` |
+| `modbus` | `# Modbus configuration` |
+
+Fehlt ein Abschnitt (weder im Dateitext noch als aktiver YAML-Schlüssel), wird er aus dem `LAMBDA_WP_CONFIG_TEMPLATE` (`const_base.py`) in der korrekten Reihenfolge eingefügt. Bestehende Abschnitte bleiben **unverändert**.
+
+**Wichtig:** Die Funktion führt nie ein blindes Anhängen am Dateiende durch. Fehlende Abschnitte werden exakt an der richtigen Position zwischen den vorhandenen Abschnitten eingefügt.
+
+---
+
+## Backup-System
+
+Vor jeder Änderung an der `lambda_wp_config.yaml` wird ein Backup angelegt:
+
+```
+config/
+└── lambda_heat_pumps/
+    └── backup/
+        ├── lambda_wp_config.yaml.backup          ← Inline-Backup (direkt neben Originaldatei)
+        └── lambda_wp_config.<migration>_<timestamp>.yaml
+```
+
+Backup-Retention-Zeiten (konfigurierbar in `const_migration.py`):
+
+| Dateityp | Aufbewahrung |
+|----------|-------------|
+| Registry-Backups (Entity, Device, Config) | 30 Tage |
+| `lambda_wp_config.yaml`-Backups | 60 Tage |
+| Alte `.backup`-Dateien | 7 Tage |
+
+---
+
+## Versionierte Migrations­funktionen
+
+Diese Funktionen werden einmalig ausgeführt, wenn eine Installation von einer älteren Version hochgestuft wird:
+
+### `migrate_to_legacy_names()` – Version 2
+
+Bereinigt die Entity-Registry: Entfernt alle Climate- und Sensor-Entities, die nicht mehr dem aktuellen Namensschema entsprechen. Wird benötigt, wenn `use_legacy_modbus_names` umgestellt wurde oder das Namensschema sich geändert hat.
+
+### `migrate_to_cycling_offsets()` – Version 3 (deprecated)
+
+Fügte den `cycling_offsets`-Abschnitt zur `lambda_wp_config.yaml` hinzu. Seit Version 7 übernimmt `migrate_lambda_config_sections()` diese Aufgabe template-basiert. Die Funktion bleibt für Rückwärtskompatibilität erhalten.
+
+### `migrate_to_unified_config()` – Version 7
+
+Führte die template-basierte Migration aller Config-Abschnitte ein. Ersetzt die einzelnen Abschnittsmigrations-Funktionen der Versionen 3–6.
+
+---
+
+## Entity-Duplikat-Cleanup (`async_remove_duplicate_entity_suffixes`)
+
+Home Assistant vergibt bei Konflikten in der Entity-Registry automatisch Suffixe wie `_2`, `_3`. Diese Funktion bereinigt solche Duplikate beim Setup:
+
+**Sammelphase:**
+1. Alle Entities des aktuellen Config-Eintrags mit `_2`/`_3`-Suffix
+2. Verwaiste Duplikate (Config-Entry-ID existiert nicht mehr, aber Entity ist noch registriert)
+
+**Löschphase** (für jeden Kandidaten):
+- Ist die Ziel-`entity_id` (ohne Suffix) noch frei? → **Umbenennen** statt Löschen (verhindert ungewollte Wiederherstellung durch HA beim nächsten Start)
+- Gleiche `unique_id` wie Basiseintrag? → Basiseintrag erst entfernen, dann umbenennen
+- Echtes Duplikat mit anderer `unique_id`? → Löschen
+
+Ausgenommen sind Entities mit `config_parameter_` in der `entity_id` (interne Konfigurationsparameter).
+
+---
+
+## Erweiterung: Neue Migrations­schritte hinzufügen
+
+### Neuen Versions-Schritt (einmalig)
+
+1. `const_migration.py`: Neuen Eintrag in `MigrationVersion` hinzufügen
+2. `migration.py`: Neue `migrate_to_<name>()` Funktion implementieren
+3. `__init__.py`: In `async_migrate_entry()` den neuen Schritt einbinden
+
+### Neuen Config-Datei-Schritt (laufend)
+
+1. `const_base.py`: `LAMBDA_WP_CONFIG_TEMPLATE` aktualisieren (neuen Schlüssel/Abschnitt einfügen)
+2. `migration.py` → `migrate_lambda_config_sections()`: Neuen Prüf- und Einfüge-Block nach dem Muster der bestehenden Schritte B/C hinzufügen:
+
+```python
+# Muster für neuen Migrationsschritt:
+if "abschnittsname" in section_ranges:
+    s, e = section_ranges["abschnittsname"]
+    section_text = content_n[s:e]
+    inserts = []
+    for match in re.finditer(r"\n((?:#\s+|\s+))anker_schluessel:[^\n]*", section_text):
+        line_end = section_text.find("\n", match.end())
+        if line_end == -1:
+            line_end = len(section_text)
+        next_start = line_end + 1
+        next_end = section_text.find("\n", next_start)
+        if next_end == -1:
+            next_end = len(section_text)
+        next_line = section_text[next_start:next_end] if next_start < len(section_text) else ""
+        if "neuer_schluessel:" in next_line:
+            continue
+        prefix = match.group(1)
+        new_line = "\n" + prefix + "neuer_schluessel: 0      # Beschreibung"
+        inserts.append((line_end, new_line))
+    for pos, new_line in sorted(inserts, key=lambda x: -x[0]):
+        section_text = section_text[:pos] + new_line + section_text[pos:]
+    if inserts:
+        content_n = content_n[:s] + section_text + content_n[e:]
+        content = content_n
+        content_modified = True
+        # Positionen neu berechnen
+        content_n, ranges = _find_section_ranges_in_content(content)
+        section_ranges = {name: (s, e) for s, e, name in ranges}
+```
+
+3. Tests in `tests/test_offset_features.py` (oder passendem Testmodul) ergänzen
+
+---
+
+## Wichtige Konstanten (`const_migration.py`)
+
+| Konstante | Wert | Bedeutung |
+|-----------|------|-----------|
+| `MIGRATION_TIMEOUT_SECONDS` | 300 | Timeout pro Migrationsschritt |
+| `BACKUP_RETENTION_DAYS["lambda_config"]` | 60 | Aufbewahrung Config-Backups |
+| `CLEANUP_INTERVAL_DAYS` | 7 | Cleanup-Intervall für alte Backups |
+| `ROLLBACK_ENABLED` | True | Rollback bei kritischen Fehlern aktiv |
+| `CRITICAL_ERROR_THRESHOLD` | 0.5 | Ab 50% fehlgeschlagener Migrationen: Rollback |
+| `MIGRATION_MAX_RETRIES` | 3 | Wiederholungsversuche pro Migration |
+
+---
+
+## Betroffene Dateien
+
+| Datei | Rolle |
+|-------|-------|
+| `custom_components/lambda_heat_pumps/migration.py` | Alle Migrationsfunktionen |
+| `custom_components/lambda_heat_pumps/const_migration.py` | Versionsnummern, Konstanten, Standardwerte |
+| `custom_components/lambda_heat_pumps/const_base.py` | `LAMBDA_WP_CONFIG_TEMPLATE` (Vorlage für neue Abschnitte) |
+| `custom_components/lambda_heat_pumps/utils.py` | `migrate_lambda_config_sections()` Delegation, `load_lambda_config()` |
+| `custom_components/lambda_heat_pumps/__init__.py` | `async_migrate_entry()` – Einstiegspunkt für versionierte Migrationen |
+| `tests/test_offset_features.py` | Tests für Offset- und Config-Migrationsschritte |

--- a/docs/docs/Entwickler/modbus-serialisierung.md
+++ b/docs/docs/Entwickler/modbus-serialisierung.md
@@ -4,6 +4,8 @@ title: "Modbus-Serialisierung - Technische Dokumentation"
 
 # Modbus-Serialisierung - Technische Dokumentation
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Dokumentation beschreibt die Serialisierung von Modbus-Operationen in der Lambda Heat Pumps Integration, um Transaction ID Mismatches zu vermeiden.
 
 ## Übersicht

--- a/docs/docs/Entwickler/modbus-wp-config.md
+++ b/docs/docs/Entwickler/modbus-wp-config.md
@@ -255,45 +255,35 @@ cycling_offsets:
             self._energy_offsets = config.get("energy_consumption_offsets", {})
 ```
 
-3. **Anwendung auf Sensoren:** Der Offset wird zum Sensorwert addiert:
+3. **Anwendung auf Sensoren:** Der Offset wird **einmalig beim HA-Start** durch `_apply_cycling_offset()` angewendet (aufgerufen aus `async_added_to_hass()`). `increment_cycling_counter()` enthält **keinen** Offset-Code mehr:
 
-```880:910:custom_components/lambda_heat_pumps/sensor.py
-        """Apply cycling offset from configuration."""
-        try:
-            # Lade die Cycling-Offsets aus der Konfiguration
-            from .utils import load_lambda_config
-            config = await load_lambda_config(self.hass)
-            cycling_offsets = config.get("cycling_offsets", {})
-            
-            if not cycling_offsets:
-                _LOGGER.debug(f"No cycling offsets found for {self.entity_id}")
-                return
-            
-            # Bestimme den Device-Key (z.B. "hp1")
-            device_key = f"hp{self._hp_index}"
-            
-            if device_key not in cycling_offsets:
-                _LOGGER.debug(f"No cycling offsets found for device {device_key}")
-                return
-            
-            # Hole den aktuellen Offset für diesen Sensor
-            current_offset = cycling_offsets[device_key].get(self._sensor_id, 0)
-            
-            # Hole den bereits angewendeten Offset aus den Attributen
-            applied_offset = getattr(self, "_applied_offset", 0)
-            
-            # Berechne die Differenz zwischen aktuellem und bereits angewendetem Offset
-            offset_difference = current_offset - applied_offset
-            
-            # Debug-Log für bessere Nachverfolgung
-            _LOGGER.debug(
-                f"Offset calculation for {self.entity_id}: current={current_offset}, applied={applied_offset}, difference={offset_difference}"
+```python
+# sensor.py – LambdaCyclingSensor._apply_cycling_offset()
+async def _apply_cycling_offset(self):
+    config = await load_lambda_config(self.hass)
+    cycling_offsets = config.get("cycling_offsets", {})
+
+    device_key = f"hp{self._hp_index}"
+    if device_key not in cycling_offsets:
+        return
+
+    current_offset = cycling_offsets[device_key].get(self._sensor_id, 0)
+    applied_offset = getattr(self, "_applied_offset", 0)
+    offset_difference = current_offset - applied_offset   # nur Differenz!
+
+    if offset_difference != 0:
+        self._cycling_value = int(self._cycling_value + offset_difference)
+        self._applied_offset = current_offset
+        self.async_write_ha_state()
 ```
+
+Der bereits angewendete Offset wird im State-Attribut `applied_offset` persistiert, sodass nach einem HA-Neustart nicht erneut der volle Offset addiert wird.
 
 **Hinweise:**
 - Gilt nur für **Total‑Sensoren**, nicht für Daily/Monthly/Yearly.
-- Werte sind absolute Zähler (keine Deltas).
-- Der Offset wird einmalig beim Sensor-Start angewendet.
+- Werte sind absolute Zähler (keine Deltas); **positive und negative** Werte sind erlaubt.
+- Der Offset wird einmalig beim Sensor-Start angewendet (differenzbasiert).
+- `increment_cycling_counter()` kennt keinen Offset — er erhöht rein um +1.
 
 ## energy_consumption_sensors
 
@@ -354,10 +344,12 @@ Offsets für Total‑Energieverbrauch (kWh). Nützlich nach Pumpentausch oder Z�
 ```yaml
 energy_consumption_offsets:
   hp1:
-    heating_energy_total: 5000.0
+    heating_energy_total: 5000.0            # kWh, elektrisch
     hot_water_energy_total: 2000.0
     cooling_energy_total: 500.0
     defrost_energy_total: 150.0
+    heating_thermal_energy_total: 6500.0    # kWh, thermisch (optional)
+    hot_water_thermal_energy_total: 2600.0  # kWh, thermisch (optional)
   hp2:
     heating_energy_total: 150.5
     hot_water_energy_total: 45.25
@@ -402,11 +394,25 @@ energy_consumption_offsets:
             self._energy_offsets = config.get("energy_consumption_offsets", {})
 ```
 
-3. **Anwendung:** Der Offset wird zu den Energieverbrauchswerten addiert (ähnlich wie bei cycling_offsets).
+3. **Anwendung:** Zwei Mechanismen, beide differenzbasiert:
+   - `_apply_energy_offset()` in `sensor.py` — einmalig beim HA-Start für den Startwert
+   - `increment_energy_consumption_counter()` in `utils.py` — bei jedem Energie-Update (prüft, ob Offset sich geändert hat, und addiert nur die Differenz)
+
+```python
+# utils.py – increment_energy_consumption_counter()
+offset = float(device_offsets.get(sensor_id, 0.0))
+if hasattr(energy_entity, "_applied_offset"):
+    if energy_entity._applied_offset != offset:
+        new_value += offset - energy_entity._applied_offset  # nur Differenz
+        energy_entity._applied_offset = offset
+```
 
 **Hinweise:**
 - Alle Werte in **kWh**.
 - Gilt nur für **Total‑Sensoren** (nicht Daily/Monthly/Yearly).
+- Positive und **negative** Werte sind erlaubt.
+- Elektrische Offsets: `{mode}_energy_total` (z. B. `heating_energy_total`).
+- Thermische Offsets: `{mode}_thermal_energy_total` (z. B. `heating_thermal_energy_total`) — optional, selbe Mechanik.
 
 ## modbus
 
@@ -518,7 +524,7 @@ sensors_names_override:
   - id: hp1_return_temp
     override_name: "Rücklauf Temperatur"
 
-# Cycling‑Offsets
+# Cycling‑Offsets (positive oder negative Ganzzahlen, nur Total-Sensoren)
 cycling_offsets:
   hp1:
     heating_cycling_total: 2500
@@ -534,13 +540,15 @@ energy_consumption_sensors:
   hp2:
     sensor_entity_id: "sensor.shelly_lambda_gesamt_leistung"
 
-# Energieverbrauchs‑Offsets (kWh)
+# Energieverbrauchs‑Offsets (kWh, positive oder negative Werte, nur Total-Sensoren)
 energy_consumption_offsets:
   hp1:
     heating_energy_total: 5000.0
     hot_water_energy_total: 2000.0
     cooling_energy_total: 500.0
     defrost_energy_total: 150.0
+    heating_thermal_energy_total: 6500.0    # optional: thermische Energie
+    hot_water_thermal_energy_total: 2600.0  # optional: thermische Energie
 
 # Modbus‑Parameter
 modbus:

--- a/docs/docs/Entwickler/modbus-wp-config.md
+++ b/docs/docs/Entwickler/modbus-wp-config.md
@@ -4,6 +4,8 @@ title: "modbus_wp_config.yaml (Entwickler)"
 
 # modbus_wp_config.yaml – Entwicklereinstellungen
 
+*Zuletzt geändert am 21.03.2026*
+
 Die Datei `modbus_wp_config.yaml` ermöglicht Entwicklern, das Verhalten der Lambda Heat Pumps Integration auf Register‑Ebene anzupassen. Dies betrifft vor allem Register‑Deaktivierung, Sensor‑Namensüberschreibungen, Zähler‑Offsets, Energie‑Sensoren und Modbus‑Parameter.
 
 **Pfad:** `config/lambda_wp_config.yaml`

--- a/docs/docs/Entwickler/offset-system.md
+++ b/docs/docs/Entwickler/offset-system.md
@@ -1,0 +1,343 @@
+---
+title: "Offset-System"
+---
+
+# Offset-System – Technische Dokumentation
+
+*Zuletzt geändert am 28.03.2026*
+
+Das Offset-System ermöglicht es, historische Zählerstände beim Austausch einer Wärmepumpe oder nach einem Zählerreset nahtlos fortzuführen. Es gibt zwei unabhängige Offset-Typen: **Cycling-Offsets** (Betriebszyklen) und **Energie-Offsets** (Verbrauchsmengen in kWh).
+
+---
+
+## Übersicht
+
+| Merkmal | Cycling-Offsets | Energie-Offsets |
+|---------|----------------|-----------------|
+| Sensor-Klasse | `LambdaCyclingSensor` | `LambdaEnergyConsumptionSensor` |
+| Einheit | Zyklen (Integer) | kWh (Float) |
+| Betroffene Perioden | nur `*_total` | nur `*_total` |
+| YAML-Schlüssel | `cycling_offsets` | `energy_consumption_offsets` |
+| Konfiguration | `lambda_wp_config.yaml` | `lambda_wp_config.yaml` |
+| Anwendungszeitpunkt | einmal beim HA-Start (async_added_to_hass) | einmal beim HA-Start (async_added_to_hass) |
+| Persistierung | Attribut `applied_offset` im HA-State | Attribut `applied_offset` im HA-State |
+| Datenspeicherung in utils.py | nein | nein |
+
+---
+
+## 1. Cycling-Offsets
+
+### Welche Sensoren erhalten Cycling-Offsets?
+
+Ausschließlich Sensoren, deren `sensor_id` auf `_total` endet:
+
+| Sensor-ID | Beschreibung |
+|-----------|-------------|
+| `heating_cycling_total` | Gesamtzahl Heizzyklen |
+| `hot_water_cycling_total` | Gesamtzahl Warmwasserzyklen |
+| `cooling_cycling_total` | Gesamtzahl Kühlzyklen |
+| `defrost_cycling_total` | Gesamtzahl Abtauzyklen |
+| `compressor_start_cycling_total` | Gesamtzahl Kompressorstarts |
+
+Daily-, Monthly-, Yearly-Sensoren (`*_daily`, `*_monthly`, `*_yearly`) erhalten **keine** Offsets.
+
+### Wie wird der Offset angewendet? – Differenzmethode
+
+Der Offset wird **nicht blind addiert**, sondern es wird immer nur die **Differenz** zwischen dem aktuell konfigurierten Offset und dem bereits angewendeten Offset (`_applied_offset`) berechnet und addiert. Das verhindert Doppelzählung bei mehrfachem HA-Neustart.
+
+```python
+# _apply_cycling_offset() in sensor.py
+current_offset = cycling_offsets[device_key].get(self._sensor_id, 0)
+applied_offset = getattr(self, "_applied_offset", 0)
+
+offset_difference = current_offset - applied_offset   # Nur die Änderung
+
+if offset_difference != 0:
+    self._cycling_value = int(self._cycling_value + offset_difference)
+    self._applied_offset = current_offset
+    self.async_write_ha_state()
+```
+
+**Beispiel:**
+
+| Ereignis | `_cycling_value` | `_applied_offset` | `current_offset` | Differenz |
+|----------|----------------:|------------------:|-----------------:|----------:|
+| Erststart, Offset = 1500 | 0 → **1500** | 0 → 1500 | 1500 | +1500 |
+| HA-Neustart, Offset unverändert | 1500 (restored) | 1500 (restored) | 1500 | 0 – kein Effekt |
+| Offset auf 1600 geändert | 1500 → **1600** | 1500 → 1600 | 1600 | +100 |
+
+### Ablauf beim HA-Start
+
+```
+async_added_to_hass()
+  ├── async_restore_last_state()
+  │     ├── _cycling_value  ← aus State
+  │     └── _applied_offset ← aus State-Attribut "applied_offset"
+  └── _apply_cycling_offset()          ← nur für *_total-Sensoren
+        └── Differenz berechnen & ggf. addieren
+```
+
+### Persistierung des `applied_offset`
+
+Der bereits angewendete Offset wird als State-Attribut gespeichert, damit er nach einem HA-Neustart wiederhergestellt werden kann:
+
+```python
+# extra_state_attributes (LambdaCyclingSensor, sensor.py)
+if self._sensor_id.endswith("_total"):
+    attrs["applied_offset"] = getattr(self, "_applied_offset", 0)
+```
+
+Bei `async_restore_last_state()` wird er zurückgelesen:
+```python
+self._applied_offset = last_state.attributes.get("applied_offset", 0)
+```
+
+### Beziehung zu `increment_cycling_counter()` (utils.py)
+
+`increment_cycling_counter()` erhöht den Zähler bei jedem erkannten Zustandswechsel um **genau 1** – **ohne** Offset-Logik. Der Offset wird ausschließlich durch `_apply_cycling_offset()` beim Start angewendet. Dies war vor V2.4.0 eine Fehlerquelle (Bug B-1): Die Funktion addierte fälschlicherweise den vollen YAML-Offset bei jedem Zyklus-Ereignis.
+
+```python
+# increment_cycling_counter() – korrekte Version (seit V2.4.0)
+new_value = int(current + 1)   # immer +1, kein Offset
+cycling_entity.set_cycling_value(new_value)
+```
+
+---
+
+## 2. Energie-Offsets
+
+### Welche Sensoren erhalten Energie-Offsets?
+
+Ausschließlich `*_total`-Sensoren der Klasse `LambdaEnergyConsumptionSensor`. Es gibt zwei Untertypen:
+
+**Elektrische Energie-Offsets** (`{mode}_energy_total`):
+
+| Sensor-ID | Beschreibung |
+|-----------|-------------|
+| `heating_energy_total` | Elektrischer Gesamtverbrauch Heizen |
+| `hot_water_energy_total` | Elektrischer Gesamtverbrauch Warmwasser |
+| `cooling_energy_total` | Elektrischer Gesamtverbrauch Kühlen |
+| `defrost_energy_total` | Elektrischer Gesamtverbrauch Abtauen |
+
+**Thermische Energie-Offsets** (`{mode}_thermal_energy_total`, optional):
+
+| Sensor-ID | Beschreibung |
+|-----------|-------------|
+| `heating_thermal_energy_total` | Thermischer Gesamtoutput Heizen |
+| `hot_water_thermal_energy_total` | Thermischer Gesamtoutput Warmwasser |
+| `cooling_thermal_energy_total` | Thermischer Gesamtoutput Kühlen |
+| `defrost_thermal_energy_total` | Thermischer Gesamtoutput Abtauen |
+
+### Wie wird der Offset angewendet? – Differenzmethode
+
+Gleiche Logik wie bei Cycling-Offsets. Der Sensor-Schlüssel wird aus `mode` und Sensor-Typ (`electrical` / `thermal`) zusammengesetzt:
+
+```python
+# _apply_energy_offset() in sensor.py
+sensor_id = f"{self._mode}_energy_total"          # elektrisch
+# oder:
+sensor_id = f"{self._mode}_thermal_energy_total"  # thermisch
+
+current_offset = energy_offsets[device_key].get(sensor_id, 0.0)
+applied_offset = getattr(self, "_applied_offset", 0.0)
+offset_difference = current_offset - applied_offset
+
+if offset_difference != 0:
+    self._energy_value += float(offset_difference)
+    self._applied_offset = current_offset
+    self.async_write_ha_state()
+```
+
+### Ablauf beim HA-Start
+
+```
+async_added_to_hass()
+  ├── async_restore_last_state()
+  │     ├── _energy_value   ← aus State
+  │     └── _applied_offset ← aus State-Attribut "applied_offset"
+  └── _apply_energy_offset()            ← nur für period == "total"
+        └── Differenz berechnen & ggf. addieren
+```
+
+### Persistierung des `applied_offset`
+
+```python
+# extra_state_attributes (LambdaEnergyConsumptionSensor, sensor.py)
+attrs["applied_offset"] = self._applied_offset
+```
+
+Wiederherstellung:
+```python
+self._applied_offset = float(attrs.get("applied_offset", 0.0))
+```
+
+### Beziehung zu `increment_energy_consumption_counter()` (utils.py)
+
+Diese Funktion liest den Quellsensor (externer Verbrauchssensor), berechnet das Delta zum letzten Wert und schreibt es auf alle 7 Perioden (`ENERGY_INCREMENT_PERIODS`):
+
+```python
+ENERGY_INCREMENT_PERIODS = ["total", "daily", "monthly", "yearly", "2h", "4h", "hourly"]
+```
+
+Der Energie-Offset wird dabei **nicht** in `increment_energy_consumption_counter()` angewendet, sondern ausschließlich durch `_apply_energy_offset()` beim HA-Start.
+
+---
+
+## 3. Struktur der `lambda_wp_config.yaml`
+
+Die Konfigurationsdatei liegt unter `config/lambda_wp_config.yaml` und enthält fünf Abschnitte. Offsets befinden sich in `cycling_offsets` und `energy_consumption_offsets`.
+
+### Vollständige annotierte Struktur
+
+```yaml
+# ─────────────────────────────────────────────────────────────
+# 1. Deaktivierte Modbus-Register (Pflichtfeld, kann leer sein)
+# ─────────────────────────────────────────────────────────────
+disabled_registers:
+  - 2004   # Beispiel: boil1_actual_circulation_temp deaktivieren
+
+# ─────────────────────────────────────────────────────────────
+# 2. Sensor-Namen überschreiben (nur bei use_legacy_modbus_names: true)
+# ─────────────────────────────────────────────────────────────
+#sensors_names_override:
+#- id: name_of_the_sensor_to_override_example
+#  override_name: new_name_of_the_sensor_example
+
+# ─────────────────────────────────────────────────────────────
+# 3. Cycling-Offsets  (Integer, positiv oder negativ)
+# ─────────────────────────────────────────────────────────────
+cycling_offsets:
+  hp1:
+    heating_cycling_total: 1200            # HP1 hatte bereits 1200 Heizzyklen
+    hot_water_cycling_total: 450
+    cooling_cycling_total: 0
+    defrost_cycling_total: 30
+    compressor_start_cycling_total: 8500   # Gesamtzahl Kompressorstarts
+  hp2:
+    heating_cycling_total: 0
+    hot_water_cycling_total: 0
+    cooling_cycling_total: 0
+    defrost_cycling_total: 0
+    compressor_start_cycling_total: 0
+
+# ─────────────────────────────────────────────────────────────
+# 4. Quellsensoren für die Energieverbrauchsberechnung
+# ─────────────────────────────────────────────────────────────
+energy_consumption_sensors:
+  hp1:
+    sensor_entity_id: "sensor.lambda_wp_verbrauch"           # elektrisch (Wh oder kWh)
+    # thermal_sensor_entity_id: "sensor.lambda_wp_waerme"   # thermisch, optional (Wh oder kWh)
+  # hp2:
+  #   sensor_entity_id: "sensor.lambda_wp_verbrauch2"
+
+# ─────────────────────────────────────────────────────────────
+# 5. Energie-Offsets  (Float in kWh, positiv oder negativ)
+#    Wirken ausschließlich auf *_total-Sensoren
+# ─────────────────────────────────────────────────────────────
+energy_consumption_offsets:
+  hp1:
+    # Elektrische Offsets:
+    heating_energy_total: 1500.75          # kWh, HP1 hatte schon 1500,75 kWh Heizen
+    hot_water_energy_total: 320.0
+    cooling_energy_total: 0.0
+    defrost_energy_total: 12.5
+    # Thermische Offsets (optional):
+    heating_thermal_energy_total: 6500.0   # kWh thermischer Output Heizen
+    hot_water_thermal_energy_total: 1400.0
+
+# ─────────────────────────────────────────────────────────────
+# 6. Modbus-Konfiguration
+# ─────────────────────────────────────────────────────────────
+#modbus:
+#  int32_register_order: "high_first"   # oder "low_first"
+```
+
+### Schlüssel-Referenz
+
+#### `cycling_offsets`
+
+```
+cycling_offsets:
+  hp{N}:                               # N = 1..num_hps
+    {mode}_cycling_total: <int>
+```
+
+| Platzhalter | Erlaubte Werte |
+|-------------|----------------|
+| `{N}` | 1, 2, … (Anzahl der Wärmepumpen) |
+| `{mode}` | `heating`, `hot_water`, `cooling`, `defrost`, `compressor_start` |
+| Wert | Integer, positiv oder negativ |
+
+#### `energy_consumption_offsets`
+
+```
+energy_consumption_offsets:
+  hp{N}:
+    {mode}_energy_total: <float>              # elektrisch
+    {mode}_thermal_energy_total: <float>      # thermisch, optional
+```
+
+| Platzhalter | Erlaubte Werte |
+|-------------|----------------|
+| `{N}` | 1, 2, … |
+| `{mode}` | `heating`, `hot_water`, `cooling`, `defrost` |
+| Wert | Float in **kWh**, positiv oder negativ |
+
+**Wichtig:** Werte immer in **kWh** angeben. Der Quellsensor darf Wh oder kWh liefern – die Konvertierung erfolgt automatisch in `increment_energy_consumption_counter()`.
+
+---
+
+## 4. Validierung der Offset-Werte
+
+Ungültige Offset-Einträge werden beim Laden der Konfiguration abgefangen (`load_lambda_config()` / `utils.py`). Die Validierung prüft ausschließlich, ob der Wert numerisch ist:
+
+```python
+if not isinstance(value, (int, float)):
+    _LOGGER.warning("Ungültiger Offset-Wert %s für %s – wird ignoriert (Wert = 0)", value, key)
+    value = 0
+```
+
+Negative Werte sind **ausdrücklich erlaubt** – sie subtrahieren vom Gesamtwert (z. B. nach einem Zählerreset auf einen bekannten Zwischenstand).
+
+---
+
+## 5. Gesamtablauf – Sequenzdiagramm
+
+```
+HA-Start
+  │
+  ├─ load_lambda_config()           → liest lambda_wp_config.yaml, cacht in hass.data
+  │
+  ├─ LambdaCyclingSensor.async_added_to_hass()   [für jeden *_total-Sensor]
+  │     ├─ Restore: _cycling_value, _applied_offset
+  │     └─ _apply_cycling_offset()
+  │           ├─ current_offset  ← aus cycling_offsets[hp{N}][sensor_id]
+  │           ├─ offset_diff     = current_offset - _applied_offset
+  │           ├─ _cycling_value += offset_diff   (nur wenn ≠ 0)
+  │           └─ _applied_offset = current_offset
+  │
+  └─ LambdaEnergyConsumptionSensor.async_added_to_hass()  [für jeden *_total-Sensor]
+        ├─ Restore: _energy_value, _applied_offset
+        └─ _apply_energy_offset()
+              ├─ current_offset  ← aus energy_consumption_offsets[hp{N}][{mode}_energy_total]
+              │                     oder [hp{N}][{mode}_thermal_energy_total]
+              ├─ offset_diff     = current_offset - _applied_offset
+              ├─ _energy_value  += offset_diff    (nur wenn ≠ 0)
+              └─ _applied_offset = current_offset
+
+Laufender Betrieb
+  ├─ increment_cycling_counter()     → +1, kein Offset
+  └─ increment_energy_consumption_counter() → Delta aus Quellsensor, kein Offset
+```
+
+---
+
+## 6. Betroffene Dateien
+
+| Datei | Rolle |
+|-------|-------|
+| `custom_components/lambda_heat_pumps/sensor.py` | `_apply_cycling_offset()`, `_apply_energy_offset()`, `extra_state_attributes` |
+| `custom_components/lambda_heat_pumps/utils.py` | `increment_cycling_counter()`, `increment_energy_consumption_counter()`, `load_lambda_config()` |
+| `custom_components/lambda_heat_pumps/const_base.py` | `LAMBDA_WP_CONFIG_TEMPLATE`, `ENERGY_INCREMENT_PERIODS` |
+| `config/lambda_wp_config.yaml` | Konfigurationsdatei (Laufzeit) |
+| `tests/test_offset_features.py` | Unit-Tests für alle Offset-Szenarien |

--- a/docs/docs/Entwickler/register-reihenfolge-int32.md
+++ b/docs/docs/Entwickler/register-reihenfolge-int32.md
@@ -4,6 +4,8 @@ title: "Register-Reihenfolge für int32-Sensoren (Issue #22)"
 
 # Register-Reihenfolge für int32-Sensoren
 
+*Zuletzt geändert am 21.03.2026*
+
 Technische Dokumentation zur konfigurierbaren Register-Reihenfolge (Register/Word Order) bei 32-Bit-Modbus-Werten. Basis: [Issue #22](https://github.com/GuidoJeuken-6512/lambda_heat_pumps/issues/22); Implementierung im Code (Stand: aktuell).
 
 ## Problemstellung

--- a/docs/docs/Entwickler/reset-logik-yesterday-sensoren.md
+++ b/docs/docs/Entwickler/reset-logik-yesterday-sensoren.md
@@ -4,6 +4,8 @@ title: "Reset-Logik und Yesterday-Sensoren - Technische Dokumentation"
 
 # Reset-Logik und Yesterday-Sensoren - Technische Dokumentation
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Dokumentation beschreibt die technische Implementierung der Reset-Logik für Energieverbrauchssensoren (Daily, Monthly, Yearly) und die Yesterday-Wert-Verwaltung in der Lambda Heat Pumps Integration.
 
 ## Übersicht

--- a/docs/docs/Entwickler/reset-manager.md
+++ b/docs/docs/Entwickler/reset-manager.md
@@ -4,6 +4,8 @@ title: "Reset-Manager - Technische Dokumentation"
 
 # Reset-Manager - Technische Dokumentation
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Dokumentation beschreibt die zentrale Reset-Logik für alle Sensor-Typen (Cycling und Energy) in der Lambda Heat Pumps Integration.
 
 ## Übersicht

--- a/docs/docs/Entwickler/sensoren-uebersicht.md
+++ b/docs/docs/Entwickler/sensoren-uebersicht.md
@@ -4,6 +4,8 @@ title: "Sensoren-Übersicht - Technische Dokumentation"
 
 # Sensoren-Übersicht - Technische Dokumentation
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Dokumentation listet alle Sensoren der Lambda Heat Pumps Integration auf, gruppiert nach Device-Typ und kategorisiert nach nativ (direkt aus Modbus) oder berechnet.
 
 ## Legende

--- a/docs/docs/Entwickler/status-sensoren-history-grafana.md
+++ b/docs/docs/Entwickler/status-sensoren-history-grafana.md
@@ -1,5 +1,7 @@
 # Plan: Status-Sensoren – History & Grafana-Visualisierung
 
+*Zuletzt geändert am 21.03.2026*
+
 **Status:** Entwurf
 **Betrifft:** Alle `txt_mapping: True`-Sensoren (operating_state, state, error_state, operating_mode, …)
 

--- a/docs/docs/Entwickler/unique-id-name-prefix-kopplung.md
+++ b/docs/docs/Entwickler/unique-id-name-prefix-kopplung.md
@@ -4,6 +4,8 @@ title: "unique_id – Kopplung an name_prefix: Problem und Lösung"
 
 # unique_id – Kopplung an name_prefix: Problem und Lösung
 
+*Zuletzt geändert am 21.03.2026*
+
 Diese Seite beschreibt, warum die Ableitung der `unique_id` aus dem vom Nutzer konfigurierbaren `name_prefix` ein strukturelles Problem darstellt, welche Auswirkungen das hat und wie eine verlustfreie Migration zur stabilen `entry_id`-basierten Lösung aussieht.
 
 ---

--- a/docs/docs/FAQ/FAQ.md
+++ b/docs/docs/FAQ/FAQ.md
@@ -4,11 +4,11 @@ title: "FAQ"
 
 # Häufig gestellte Fragen
 
+*Zuletzt geändert am 21.03.2026*
+
 Hier finden Sie Antworten auf häufige Fragen zur Lambda Heat Pumps Integration.
 
 ## Themen
-
-### ⚠️ ⚠️ Achtung, die Funktion der Offsets für Sensoren ist fehlerhaft, bitte im Moment nicht einsetzten!
 
 - **[COP-Sensoren](cop-sensoren.md)** – Periodische Werte, Unknown, Total-Baseline
 

--- a/docs/docs/FAQ/cop-sensoren.md
+++ b/docs/docs/FAQ/cop-sensoren.md
@@ -4,6 +4,8 @@ title: "FAQ – COP-Sensoren"
 
 # COP-Sensoren: Periodische Werte und Anzeige
 
+*Zuletzt geändert am 21.03.2026*
+
 ## Periodische COP-Werte bauen sich erst auf
 
 Die **periodischen** COP-Sensoren (Daily, Monthly, Yearly) beziehen ihre Werte aus den jeweiligen Energieverbrauchssensoren für den gleichen Zeitraum. Diese Werte **bauen sich erst im Lauf der Zeit auf**:

--- a/docs/docs/FAQ/falsche-keine-sensorwerte.md
+++ b/docs/docs/FAQ/falsche-keine-sensorwerte.md
@@ -4,6 +4,8 @@ title: "FAQ – Falsche / keine Sensorwerte"
 
 # Falsche oder keine Sensorwerte
 
+*Zuletzt geändert am 21.03.2026*
+
 Hier finden Sie die häufigsten Ursachen und Lösungen, wenn Sensoren **falsche Werte** anzeigen oder **gar keine Werte** liefern.
 
 ---

--- a/docs/docs/Releases/release-2-0.md
+++ b/docs/docs/Releases/release-2-0.md
@@ -1,5 +1,7 @@
 # Release 2.0.0
 
+*Zuletzt geändert am 21.03.2026*
+
 Dokumentation basierend auf dem [GitHub Release V2.0.0](https://github.com/GuidoJeuken-6512/lambda_heat_pumps/releases/tag/V2.0.0).
 
 ---

--- a/docs/docs/Releases/release-2-2.md
+++ b/docs/docs/Releases/release-2-2.md
@@ -1,5 +1,7 @@
 # Release 2.2
 
+*Zuletzt geändert am 21.03.2026*
+
 Dokumentation basierend auf dem [GitHub Release Release2.2](https://github.com/GuidoJeuken-6512/lambda_heat_pumps/releases/tag/Release2.2).
 
 ---

--- a/docs/docs/Releases/release-2-3-4.md
+++ b/docs/docs/Releases/release-2-3-4.md
@@ -1,5 +1,7 @@
 # Release 2.3.4
 
+*Zuletzt geändert am 21.03.2026*
+
 > Version 2.3.1/3 wurde übersprungen.
 
 ---

--- a/docs/docs/Releases/release-2-3.md
+++ b/docs/docs/Releases/release-2-3.md
@@ -1,5 +1,7 @@
 # Release 2.3
 
+*Zuletzt geändert am 21.03.2026*
+
 > ⚠️ **Vor dem Update**: Erstelle ein Backup deiner Home Assistant Konfiguration (Verzeichnis `config/`) sowie der `lambda_wp_config.yaml`. Dieses Release enthält einen Breaking Change, der Entity-IDs verändern kann.
 
 ---

--- a/docs/docs/Releases/release-2-4-0.md
+++ b/docs/docs/Releases/release-2-4-0.md
@@ -4,7 +4,7 @@ title: "Release 2.4.0"
 
 # Release 2.4.0
 
-*Zuletzt geändert am 28.03.2026*
+*Zuletzt geändert am 29.03.2026*
 
 > **Aktueller Release** · Branch `V2.4.0`
 
@@ -12,7 +12,7 @@ title: "Release 2.4.0"
 
 ## Zusammenfassung
 
-Release 2.4.0 behebt mehrere Bugs: einen kritischen Fehler in der Offset-Logik für Cycling-Sensoren (Offsets wurden bei jedem Zyklus-Ereignis erneut addiert) sowie einen Fehler bei der Moduserkennung für Cycling-Zähler (verpasste Zyklen durch geteilten State zwischen Fast Poll und Full Update). Zusätzlich wurden die Dokumentation, das Konfigurations-Template und die Test-Suite vollständig aktualisiert.
+Release 2.4.0 behebt mehrere Bugs: einen kritischen Fehler in der Offset-Logik für Cycling-Sensoren (Offsets wurden bei jedem Zyklus-Ereignis erneut addiert), einen Fehler bei der Moduserkennung für Cycling-Zähler (verpasste Zyklen durch geteilten State), einen weiteren kritischen Bug, durch den Betriebsmodus-Wechsel zuverlässig erkannt, aber nie gezählt wurden (`cycling_entity` NameError in `increment_cycling_counter()`), sowie einen Bug, durch den konfigurierte Energie-Offsets beim HA-Start komplett ignoriert wurden (`_apply_energy_offset()` wurde in `async_added_to_hass()` nie aufgerufen). Zusätzlich wurden das Konfigurations-Template, das Migrationssystem, die Test-Suite und die Dokumentation vollständig aktualisiert.
 
 ---
 
@@ -93,6 +93,71 @@ last_state = self._energy_last_operating_state.get(str(hp_idx), 0)
 self._energy_last_operating_state[str(hp_idx)] = current_state
 ```
 
+### Kritisch: Flankenerkennung erkannte Wechsel, zählte aber nie
+
+**Betroffen:** `custom_components/lambda_heat_pumps/utils.py` · `increment_cycling_counter()`
+
+**Symptom:** Betriebsmodus-Wechsel (z. B. STBY-FROST → CH) wurden intern korrekt erkannt und als Flanke eingestuft — der Tages- und Gesamtzähler blieb jedoch bei 0. Im HA-Log erschienen keine Fehlermeldungen auf normalem Log-Level.
+
+**Ursache:** In `increment_cycling_counter()` wurde die Variable `cycling_entity` auf Zeile 871 referenziert (Prüfung auf `_cycling_value`), war aber erst auf Zeile 884 definiert. Bei der ersten Ausführung des `for sensor_id`-Loops löste Python einen `NameError` aus.
+
+Dieser propagierte durch `_run_cycling_edge_detection()` (kein `try/except`) bis in `_async_fast_update()`, wo er stillschweigend abgefangen wurde:
+
+```python
+except Exception as ex:
+    _LOGGER.debug("Fast poll error (non-fatal): %s", ex)  # ← nur debug, nie sichtbar
+```
+
+**Zweite Konsequenz:** Weil die Exception vor dem Schreiben von `self._last_operating_state[str(hp_idx)] = op_state_val` auftrat, wurde der gespeicherte Zustand nie aktualisiert. Beim nächsten Fast Poll (nach 2 s) sah die Flankenerkennung wieder denselben Übergang — erkannte ihn erneut, scheiterte erneut. Die Schleife lief für die gesamte Dauer des CH-Modus alle 2 Sekunden durch, ohne je einen Zyklus zu zählen.
+
+**Fix:** Die Entity-Suche (`cycling_entity = None` + Lookup-Block) wurde **vor** die Leseoperation für `current` verschoben:
+
+```python
+# Vorher (fehlerhaft) — cycling_entity undefiniert bei erstem Aufruf:
+if cycling_entity is not None and hasattr(cycling_entity, "_cycling_value"):
+    current = cycling_entity._cycling_value or 0
+...
+cycling_entity = None   # ← zu spät!
+for entry_id, comp_data in ...:
+    cycling_entity = comp_data["cycling_entities"].get(entity_id)
+
+# Nachher (korrekt):
+cycling_entity = None   # ← zuerst definieren
+for entry_id, comp_data in ...:
+    cycling_entity = comp_data["cycling_entities"].get(entity_id)
+...
+if cycling_entity is not None and hasattr(cycling_entity, "_cycling_value"):
+    current = cycling_entity._cycling_value or 0
+```
+
+### Kritisch: Energie-Offsets beim HA-Start komplett ignoriert
+
+**Betroffen:** `custom_components/lambda_heat_pumps/sensor.py` · `LambdaEnergyConsumptionSensor.async_added_to_hass()`
+
+**Symptom:** Konfigurierte `energy_consumption_offsets` aus der `lambda_wp_config.yaml` wurden beim HA-Start nicht angewendet. Sensoren wie `hot_water_energy_total` blieben am gespeicherten Rohwert — kein Offset, keine Log-Ausgabe.
+
+**Ursache:** `_apply_energy_offset()` war korrekt implementiert (differenzbasiertes Tracking, identisch zum Cycling-Mechanismus) — wurde aber nie aufgerufen. `async_added_to_hass()` rief `restore_state()` auf und anschließend `_apply_persisted_energy_state()` (die `_energy_value` mit dem rohen Coordinator-Wert überschreiben kann) — danach endete die Funktion, ohne `_apply_energy_offset()` zu rufen.
+
+**Fix:** `_apply_energy_offset()` wird jetzt am Ende von `async_added_to_hass()` aufgerufen, nach `_apply_persisted_energy_state()`, damit der Offset auf dem finalen Rohwert angewendet wird:
+
+```python
+# async_added_to_hass() – vorher (fehlerhaft):
+await self.restore_state(last_state)
+if our_state:
+    self._apply_persisted_energy_state(our_state)
+    self.async_write_ha_state()
+# ← _apply_energy_offset() nie aufgerufen, Offset ignoriert
+
+# Nachher (korrekt):
+await self.restore_state(last_state)
+if our_state:
+    self._apply_persisted_energy_state(our_state)
+    self.async_write_ha_state()
+# Offset ZULETZT anwenden — nach _apply_persisted_energy_state()
+if self._period == "total":
+    await self._apply_energy_offset()
+```
+
 ---
 
 ## Neue Funktionen
@@ -109,9 +174,9 @@ cycling_offsets:
 
 Die Validierung beim Laden prüft nur, ob der Wert numerisch ist — kein `>= 0`-Check.
 
-### Thermische Energie-Offsets dokumentiert
+### Thermische Energie-Offsets dokumentiert und migriert
 
-`energy_consumption_offsets` unterstützt neben elektrischen Offsets (`{mode}_energy_total`) auch thermische Offsets (`{mode}_thermal_energy_total`). Dies war bisher undokumentiert:
+`energy_consumption_offsets` unterstützt neben elektrischen Offsets (`{mode}_energy_total`) auch thermische Offsets (`{mode}_thermal_energy_total`). Dies war bisher undokumentiert. Die vier thermischen Schlüssel werden jetzt auch in das `LAMBDA_WP_CONFIG_TEMPLATE` geschrieben und durch das Migrationssystem automatisch in bestehende `lambda_wp_config.yaml`-Dateien eingefügt:
 
 ```yaml
 energy_consumption_offsets:
@@ -119,7 +184,38 @@ energy_consumption_offsets:
     heating_energy_total: 5000.0             # elektrisch
     heating_thermal_energy_total: 6500.0     # thermisch (optional)
     hot_water_thermal_energy_total: 2600.0   # thermisch (optional)
+    cooling_thermal_energy_total: 800.0      # thermisch (optional)
+    defrost_thermal_energy_total: 120.0      # thermisch (optional)
 ```
+
+---
+
+## Migrationssystem
+
+### Neue Migrations-Schritte in `migrate_lambda_config_sections()`
+
+Beim HA-Start prüft das Migrationssystem bestehende `lambda_wp_config.yaml`-Dateien auf fehlende Schlüssel und fügt sie automatisch ein — ohne andere Inhalte zu verändern.
+
+**Schritt 1: `compressor_start_cycling_total` in `cycling_offsets`**
+
+Dateien, die vor V2.4.0 erstellt wurden, fehlte der Schlüssel `compressor_start_cycling_total` im `cycling_offsets`-Block. Die Migration erkennt das Fehlen und fügt die Zeile nach `defrost_cycling_total:` ein — passend zur Einrückung (kommentiert oder aktiv):
+
+```yaml
+# Vorher:
+cycling_offsets:
+  hp1:
+    defrost_cycling_total: 0
+
+# Nachher:
+cycling_offsets:
+  hp1:
+    defrost_cycling_total: 0
+    compressor_start_cycling_total: 0      # Offset for compressor start total
+```
+
+**Schritt 2: Thermische Energie-Offset-Schlüssel in `energy_consumption_offsets`**
+
+Die vier thermischen Schlüssel (`heating_thermal_energy_total`, `hot_water_thermal_energy_total`, `cooling_thermal_energy_total`, `defrost_thermal_energy_total`) werden kettenweise nach `defrost_energy_total:` eingefügt, falls sie fehlen. Teilweise vorhandene Schlüssel werden übersprungen.
 
 ---
 
@@ -140,7 +236,8 @@ Das `LAMBDA_WP_CONFIG_TEMPLATE` wurde erweitert:
 
 | Datei | Änderung |
 |---|---|
-| `Anwender/lambda-wp-config.md` | Warnbanner „fehlerhaft" entfernt; negative Offsets dokumentiert; thermische Offsets im Beispiel ergänzt |
+| `Anwender/offsets.md` | **Neu**: Eigenständige, vollständige Dokumentation für Cycling- und Energie-Offsets; erklärt Differenz-Tracking, negative Offsets, alle Szenarien |
+| `Anwender/lambda-wp-config.md` | Offset-Abschnitte auf Kurzbeschreibung + Link zu `offsets.md` gekürzt; negative und thermische Offsets im Beispiel ergänzt |
 | `Anwender/historische-daten.md` | Warnbanner „fehlerhaft" entfernt; Funktionsweise-Beschreibung korrigiert (Punkt 2 beschrieb fälschlicherweise das buggy Verhalten); thermische Offsets ergänzt |
 
 > Die Hinweise `⚠️ die Funktion der Offsets ist fehlerhaft, bitte im Moment nicht einsetzen!` wurden entfernt. Cycling-Offsets können ab Version 2.4.0 ohne Einschränkung eingesetzt werden.
@@ -149,6 +246,8 @@ Das `LAMBDA_WP_CONFIG_TEMPLATE` wurde erweitert:
 
 | Datei | Änderung |
 |---|---|
+| `Entwickler/migration-system.md` | **Neu**: Vollständige technische Beschreibung des Migrationssystems (MigrationVersion-Enum, Ablauf, alle Migrationsschritte, Backup-Logik, Erweiterungsanleitung) |
+| `Entwickler/offset-system.md` | **Neu**: Vollständige technische Beschreibung des Offset-Systems (Differenz-Tracking, Persistierung via `applied_offset`, Sequenzdiagramm, YAML-Struktur) |
 | `Entwickler/cycling-sensoren.md` | Flankenerkennung-Codebeispiel aktualisiert (kein `cycling_offsets`-Parameter mehr); Increment-Logik-Beispiel auf korrekten Stand gebracht; Abschnitt 8 (Cycling-Offsets) vollständig überarbeitet; Log-Meldung korrigiert |
 | `Entwickler/modbus-wp-config.md` | `cycling_offsets`-Abschnitt: Codebeispiel zeigt jetzt `_apply_cycling_offset()` statt altem Bugcode; thermische Offsets ergänzt; negative Offsets dokumentiert; vollständiges Beispiel erweitert |
 
@@ -156,7 +255,7 @@ Das `LAMBDA_WP_CONFIG_TEMPLATE` wurde erweitert:
 
 ## Tests
 
-Neue Testdatei `tests/test_offset_features.py` mit **23 Tests**:
+Testdatei `tests/test_offset_features.py` mit **37 Tests** (23 bestehende + 9 neue Migrations-Tests + 5 neue Energie-Offset-Startup-Tests):
 
 | Testgruppe | Abgedeckte Szenarien |
 |---|---|
@@ -168,6 +267,9 @@ Neue Testdatei `tests/test_offset_features.py` mit **23 Tests**:
 | `TestEnergyOffsetIncrementDifferential` | Erster Aufruf aktualisiert `_applied_offset`; zweiter Aufruf mit gleichem Offset addiert nichts extra |
 | `TestOffsetConfigValidation` | Negative Werte bestehen Validierung; nicht-numerische Werte werden auf 0 gesetzt; thermische Schlüssel sind gültig |
 | `TestConfigTemplate` | Template enthält `cycling_offsets`, `thermal_energy_total`, `compressor_start_cycling_total` |
+| `TestMigrateCyclingOffsetCompressorStart` | **Neu**: Migration fügt `compressor_start_cycling_total` ein wenn fehlend; überspringt vorhandene Einträge; korrekte Einrückung bei aktivem Block |
+| `TestMigrateThermalEnergyOffsets` | **Neu**: Migration fügt alle 4 thermischen Energie-Schlüssel ein; korrekte Reihenfolge; überspringt bereits vorhandene; funktioniert bei mehreren HP-Blöcken |
+| `TestEnergyOffsetAppliedViaAsyncAddedToHass` | **Neu**: Energie-Offset via `async_added_to_hass()` angewendet; kein erneutes Anwenden beim zweiten Neustart; Offset nach Coordinator-State-Überschreiben korrekt; Call-Site-Absicherung für Total-Sensor; Daily-Sensor bleibt unberührt |
 
 ---
 
@@ -196,11 +298,16 @@ await increment_cycling_counter(
 
 | Datei | Art |
 |---|---|
-| `custom_components/lambda_heat_pumps/utils.py` | Bugfix: Offset-Block aus `increment_cycling_counter()` entfernt; Basiswert liest jetzt `_cycling_value` statt HA-State |
+| `custom_components/lambda_heat_pumps/utils.py` | Bugfix: Offset-Block aus `increment_cycling_counter()` entfernt; Entity-Lookup vor `current`-Leseoperation verschoben (NameError-Fix); Basiswert liest jetzt `_cycling_value` statt HA-State |
+| `custom_components/lambda_heat_pumps/sensor.py` | Bugfix: `_apply_energy_offset()` wird in `async_added_to_hass()` nach `_apply_persisted_energy_state()` aufgerufen (Energie-Offsets wurden zuvor komplett ignoriert) |
 | `custom_components/lambda_heat_pumps/coordinator.py` | Bugfix: `_energy_last_operating_state` getrennt von `_last_operating_state`; `cycling_offsets`-Parameter aus Aufrufen entfernt |
-| `custom_components/lambda_heat_pumps/const_base.py` | Erweiterung: `LAMBDA_WP_CONFIG_TEMPLATE` |
-| `tests/test_offset_features.py` | Neu: 23 Offset-Tests |
-| `docs/docs/Anwender/lambda-wp-config.md` | Dokumentation aktualisiert |
+| `custom_components/lambda_heat_pumps/const_base.py` | Erweiterung: `LAMBDA_WP_CONFIG_TEMPLATE` (thermische Offsets vollständig ergänzt) |
+| `custom_components/lambda_heat_pumps/migration.py` | Neu: Migration für `compressor_start_cycling_total` und thermische Energie-Offset-Schlüssel |
+| `tests/test_offset_features.py` | Erweitert: 37 Tests (9 neue für Migrations-Szenarien, 5 neue für Energie-Offset-Startup-Regression) |
+| `docs/docs/Anwender/offsets.md` | Neu: eigenständige Offset-Dokumentation |
+| `docs/docs/Anwender/lambda-wp-config.md` | Offset-Abschnitte gekürzt + Link zu offsets.md |
 | `docs/docs/Anwender/historische-daten.md` | Dokumentation aktualisiert |
+| `docs/docs/Entwickler/migration-system.md` | Neu: Technische Dokumentation Migrationssystem |
+| `docs/docs/Entwickler/offset-system.md` | Neu: Technische Dokumentation Offset-System |
 | `docs/docs/Entwickler/cycling-sensoren.md` | Dokumentation aktualisiert |
 | `docs/docs/Entwickler/modbus-wp-config.md` | Dokumentation aktualisiert |

--- a/docs/docs/Releases/release-2-4-0.md
+++ b/docs/docs/Releases/release-2-4-0.md
@@ -1,0 +1,174 @@
+---
+title: "Release 2.4.0"
+---
+
+# Release 2.4.0
+
+> **Aktueller Release** · Branch `V2.4.0`
+
+---
+
+## Zusammenfassung
+
+Release 2.4.0 behebt einen kritischen Bug in der Offset-Logik für Cycling-Sensoren, der dazu führte, dass konfigurierte Offsets aus der `lambda_wp_config.yaml` bei jedem Zyklus-Ereignis erneut addiert wurden statt einmalig beim Start. Zusätzlich wurden die Dokumentation, das Konfigurations-Template und die Test-Suite vollständig aktualisiert.
+
+---
+
+## Bugfixes
+
+### Kritisch: Cycling-Offset wurde bei jedem Zyklus-Ereignis erneut addiert
+
+**Betroffen:** `custom_components/lambda_heat_pumps/utils.py` · `increment_cycling_counter()`
+
+**Symptom:** Konfigurierte `cycling_offsets` aus der `lambda_wp_config.yaml` wurden nicht einmalig angewendet, sondern bei jedem erkannten Betriebsmodus-Wechsel (z. B. Wärmepumpe wechselt in Heizbetrieb) erneut auf den Gesamtzähler addiert. Bei einem konfigurierten Offset von 1500 und 10 Zyklen ergab sich:
+
+```
+Erwartet:  100 (Basiswert) + 1500 (Offset) + 10 (Zyklen) =  1610
+Tatsächlich: 100 + 1500 × 11                             = 16610
+```
+
+**Ursache:** `increment_cycling_counter()` las den vollen YAML-Offset-Wert und addierte ihn bei jedem Aufruf, ohne zu prüfen, ob er bereits im Sensorwert enthalten war. Parallel dazu wendete `_apply_cycling_offset()` in `sensor.py` den Offset korrekt einmalig beim HA-Start an — die beiden Mechanismen konkurrierten.
+
+**Fix:** Der Offset-Block wurde vollständig aus `increment_cycling_counter()` entfernt. Der Parameter `cycling_offsets` wurde aus der Funktionssignatur gestrichen. Die alleinige Verantwortung für Offsets liegt jetzt bei `_apply_cycling_offset()` in `sensor.py`, die korrekt differenzbasiert arbeitet (`_applied_offset`-Tracking).
+
+```python
+# Vorher (fehlerhaft):
+final_value = int(new_value + offset)   # offset = voller YAML-Wert, jedes Mal!
+
+# Nachher (korrekt):
+final_value = new_value                 # nur +1, kein Offset hier
+```
+
+**Wie `_apply_cycling_offset()` korrekt funktioniert (unverändert):**
+
+```
+HA-Start:
+  Gespeicherter Wert:      100
+  _applied_offset:           0  (aus Attribut, letzte Session)
+  YAML-Offset:            1500
+  Differenz:              1500  → wird addiert
+  Ergebnis:               1600  ✓
+  _applied_offset = 1500  (für nächsten Neustart gespeichert)
+
+Nächster HA-Start:
+  Gespeicherter Wert:     1600
+  _applied_offset:        1500  (wiederhergestellt)
+  YAML-Offset:            1500
+  Differenz:                 0  → nichts addiert  ✓
+
+Zyklus-Ereignis (nach Fix):
+  increment_cycling_counter() addiert nur +1
+  Ergebnis: 1600 + 1 = 1601  ✓
+```
+
+---
+
+## Neue Funktionen
+
+### Negative Offsets werden explizit unterstützt und dokumentiert
+
+Sowohl `cycling_offsets` als auch `energy_consumption_offsets` akzeptieren negative Werte. Ein negativer Offset subtrahiert den angegebenen Betrag vom Gesamtzähler — nützlich, um einen zu hohen Ausgangswert zu korrigieren.
+
+```yaml
+cycling_offsets:
+  hp1:
+    heating_cycling_total: -200   # Subtrahiert 200 von der Gesamtzahl
+```
+
+Die Validierung beim Laden prüft nur, ob der Wert numerisch ist — kein `>= 0`-Check.
+
+### Thermische Energie-Offsets dokumentiert
+
+`energy_consumption_offsets` unterstützt neben elektrischen Offsets (`{mode}_energy_total`) auch thermische Offsets (`{mode}_thermal_energy_total`). Dies war bisher undokumentiert:
+
+```yaml
+energy_consumption_offsets:
+  hp1:
+    heating_energy_total: 5000.0             # elektrisch
+    heating_thermal_energy_total: 6500.0     # thermisch (optional)
+    hot_water_thermal_energy_total: 2600.0   # thermisch (optional)
+```
+
+---
+
+## Konfigurationstemplate (`const_base.py`)
+
+Das `LAMBDA_WP_CONFIG_TEMPLATE` wurde erweitert:
+
+- `compressor_start_cycling_total` wurde zum Cycling-Offset-Beispiel hinzugefügt (fehlte bisher trotz Unterstützung)
+- Thermische Energie-Offsets (`{mode}_thermal_energy_total`) wurden als kommentierte Beispiele ergänzt
+- Hinweis auf negative Offsets wurde eingefügt
+- Kommentare auf Englisch vereinheitlicht
+
+---
+
+## Dokumentation
+
+### Benutzer-Dokumentation
+
+| Datei | Änderung |
+|---|---|
+| `Anwender/lambda-wp-config.md` | Warnbanner „fehlerhaft" entfernt; negative Offsets dokumentiert; thermische Offsets im Beispiel ergänzt |
+| `Anwender/historische-daten.md` | Warnbanner „fehlerhaft" entfernt; Funktionsweise-Beschreibung korrigiert (Punkt 2 beschrieb fälschlicherweise das buggy Verhalten); thermische Offsets ergänzt |
+
+> Die Hinweise `⚠️ die Funktion der Offsets ist fehlerhaft, bitte im Moment nicht einsetzen!` wurden entfernt. Cycling-Offsets können ab Version 2.4.0 ohne Einschränkung eingesetzt werden.
+
+### Entwickler-Dokumentation
+
+| Datei | Änderung |
+|---|---|
+| `Entwickler/cycling-sensoren.md` | Flankenerkennung-Codebeispiel aktualisiert (kein `cycling_offsets`-Parameter mehr); Increment-Logik-Beispiel auf korrekten Stand gebracht; Abschnitt 8 (Cycling-Offsets) vollständig überarbeitet; Log-Meldung korrigiert |
+| `Entwickler/modbus-wp-config.md` | `cycling_offsets`-Abschnitt: Codebeispiel zeigt jetzt `_apply_cycling_offset()` statt altem Bugcode; thermische Offsets ergänzt; negative Offsets dokumentiert; vollständiges Beispiel erweitert |
+
+---
+
+## Tests
+
+Neue Testdatei `tests/test_offset_features.py` mit **23 Tests**:
+
+| Testgruppe | Abgedeckte Szenarien |
+|---|---|
+| `TestCyclingOffsetOnStartup` | Positiver Offset einmalig addiert; negativer Offset subtrahiert; Offset 0 → keine Änderung; kein Config-Eintrag → keine Änderung |
+| `TestCyclingOffsetDifferentialTracking` | Gleicher Offset nicht erneut angewendet; erhöhter Offset addiert nur Delta; verringerter Offset subtrahiert nur Delta |
+| `TestCyclingOffsetPersistence` | `applied_offset` in State-Attributen vorhanden; nach HA-Neustart wiederhergestellt |
+| `TestIncrementCyclingCounterNoOffset` | Inkrementiert exakt um +1 ohne Offset; `cycling_offsets`-Parameter nicht mehr in Signatur (Regressionsschutz) |
+| `TestEnergyOffsetApplication` | Elektrischer Offset beim Start angewendet; negativer Offset subtrahiert; gleicher Offset nicht doppelt angewendet |
+| `TestEnergyOffsetIncrementDifferential` | Erster Aufruf aktualisiert `_applied_offset`; zweiter Aufruf mit gleichem Offset addiert nichts extra |
+| `TestOffsetConfigValidation` | Negative Werte bestehen Validierung; nicht-numerische Werte werden auf 0 gesetzt; thermische Schlüssel sind gültig |
+| `TestConfigTemplate` | Template enthält `cycling_offsets`, `thermal_energy_total`, `compressor_start_cycling_total` |
+
+---
+
+## Migration / Breaking Changes
+
+**Keine Breaking Changes für Endanwender.**
+
+Für Entwickler: Der Parameter `cycling_offsets` wurde aus `increment_cycling_counter()` entfernt. Eigene Aufrufe dieser Funktion müssen angepasst werden:
+
+```python
+# Alt (2.3.x):
+await increment_cycling_counter(
+    hass, mode=mode, hp_index=1, name_prefix="eu08l",
+    cycling_offsets=self._cycling_offsets,   # ← entfernen
+)
+
+# Neu (2.4.0):
+await increment_cycling_counter(
+    hass, mode=mode, hp_index=1, name_prefix="eu08l",
+)
+```
+
+---
+
+## Betroffene Dateien
+
+| Datei | Art |
+|---|---|
+| `custom_components/lambda_heat_pumps/utils.py` | Bugfix: Offset-Block aus `increment_cycling_counter()` entfernt |
+| `custom_components/lambda_heat_pumps/coordinator.py` | Anpassung: `cycling_offsets`-Parameter aus beiden Aufrufen entfernt |
+| `custom_components/lambda_heat_pumps/const_base.py` | Erweiterung: `LAMBDA_WP_CONFIG_TEMPLATE` |
+| `tests/test_offset_features.py` | Neu: 23 Offset-Tests |
+| `docs/docs/Anwender/lambda-wp-config.md` | Dokumentation aktualisiert |
+| `docs/docs/Anwender/historische-daten.md` | Dokumentation aktualisiert |
+| `docs/docs/Entwickler/cycling-sensoren.md` | Dokumentation aktualisiert |
+| `docs/docs/Entwickler/modbus-wp-config.md` | Dokumentation aktualisiert |

--- a/docs/docs/Releases/release-2-4-0.md
+++ b/docs/docs/Releases/release-2-4-0.md
@@ -4,7 +4,7 @@ title: "Release 2.4.0"
 
 # Release 2.4.0
 
-*Zuletzt geändert am 21.03.2026*
+*Zuletzt geändert am 28.03.2026*
 
 > **Aktueller Release** · Branch `V2.4.0`
 
@@ -12,7 +12,7 @@ title: "Release 2.4.0"
 
 ## Zusammenfassung
 
-Release 2.4.0 behebt einen kritischen Bug in der Offset-Logik für Cycling-Sensoren, der dazu führte, dass konfigurierte Offsets aus der `lambda_wp_config.yaml` bei jedem Zyklus-Ereignis erneut addiert wurden statt einmalig beim Start. Zusätzlich wurden die Dokumentation, das Konfigurations-Template und die Test-Suite vollständig aktualisiert.
+Release 2.4.0 behebt mehrere Bugs: einen kritischen Fehler in der Offset-Logik für Cycling-Sensoren (Offsets wurden bei jedem Zyklus-Ereignis erneut addiert) sowie einen Fehler bei der Moduserkennung für Cycling-Zähler (verpasste Zyklen durch geteilten State zwischen Fast Poll und Full Update). Zusätzlich wurden die Dokumentation, das Konfigurations-Template und die Test-Suite vollständig aktualisiert.
 
 ---
 
@@ -61,6 +61,36 @@ Nächster HA-Start:
 Zyklus-Ereignis (nach Fix):
   increment_cycling_counter() addiert nur +1
   Ergebnis: 1600 + 1 = 1601  ✓
+```
+
+### Cycling-Zähler: Verpasste Zyklen durch geteilten State
+
+**Betroffen:** `custom_components/lambda_heat_pumps/coordinator.py` · `_track_hp_energy_consumption()` und `_run_cycling_edge_detection()`
+**Betroffen:** `custom_components/lambda_heat_pumps/utils.py` · `increment_cycling_counter()`
+
+**Symptom:** Zwei HA-Systeme, die dieselbe Wärmepumpe überwachen, zeigten über Zeit unterschiedliche `heating_cycling_daily`-Werte. Betriebsmodusübergänge wurden nicht immer erkannt.
+
+**Ursache:** `_last_operating_state` wurde von zwei unabhängigen Code-Pfaden mit unterschiedlicher Semantik beschrieben:
+
+- **Fast Poll** (alle 2s, `coordinator.py:1615`): schreibt den zuletzt gesehenen Modbus-Wert als Flanken-Gedächtnis für die Cycling-Erkennung.
+- **Full Update** (alle 30s, `coordinator.py:2270` in `_track_hp_energy_consumption`): schreibt den zu Beginn des Full Updates gelesenen Zustand als Seiteneffekt der Energieattribution.
+
+Während eines Full Updates werden alle Fast Polls blockiert (`_full_update_running`-Flag). Wenn die WP in dieser Zeit von Zustand A → B → A wechselte, schrieb das Full Update beim Abschluss `A` zurück in `_last_operating_state`. Der nächste Fast Poll sah `last=A, cur=A` → **keine Flanke, beide Zyklen verloren**.
+
+**Fix:** Die Energieattribution erhält ein eigenes `_energy_last_operating_state`-Dict. Der Full Update schreibt ausschließlich in `_energy_last_operating_state`; `_last_operating_state` gehört allein dem Fast Poll.
+
+Zusätzlich liest `increment_cycling_counter()` jetzt `cycling_entity._cycling_value` als Basiswert für den Zähler statt `hass.states.get()`, um eine potenzielle Veraltung nach HA-Start-Wiederherstellung zu vermeiden.
+
+```python
+# _track_hp_energy_consumption – vorher:
+last_state = self._last_operating_state.get(str(hp_idx), 0)   # ← Fast-Poll-State!
+...
+self._last_operating_state[str(hp_idx)] = current_state        # ← überschreibt Fast-Poll!
+
+# Nachher:
+last_state = self._energy_last_operating_state.get(str(hp_idx), 0)
+...
+self._energy_last_operating_state[str(hp_idx)] = current_state
 ```
 
 ---
@@ -166,8 +196,8 @@ await increment_cycling_counter(
 
 | Datei | Art |
 |---|---|
-| `custom_components/lambda_heat_pumps/utils.py` | Bugfix: Offset-Block aus `increment_cycling_counter()` entfernt |
-| `custom_components/lambda_heat_pumps/coordinator.py` | Anpassung: `cycling_offsets`-Parameter aus beiden Aufrufen entfernt |
+| `custom_components/lambda_heat_pumps/utils.py` | Bugfix: Offset-Block aus `increment_cycling_counter()` entfernt; Basiswert liest jetzt `_cycling_value` statt HA-State |
+| `custom_components/lambda_heat_pumps/coordinator.py` | Bugfix: `_energy_last_operating_state` getrennt von `_last_operating_state`; `cycling_offsets`-Parameter aus Aufrufen entfernt |
 | `custom_components/lambda_heat_pumps/const_base.py` | Erweiterung: `LAMBDA_WP_CONFIG_TEMPLATE` |
 | `tests/test_offset_features.py` | Neu: 23 Offset-Tests |
 | `docs/docs/Anwender/lambda-wp-config.md` | Dokumentation aktualisiert |

--- a/docs/docs/Releases/release-2-4-0.md
+++ b/docs/docs/Releases/release-2-4-0.md
@@ -4,6 +4,8 @@ title: "Release 2.4.0"
 
 # Release 2.4.0
 
+*Zuletzt geändert am 21.03.2026*
+
 > **Aktueller Release** · Branch `V2.4.0`
 
 ---

--- a/docs/docs/Releases/release-2-4-0_en.md
+++ b/docs/docs/Releases/release-2-4-0_en.md
@@ -4,7 +4,7 @@ title: "Release 2.4.0"
 
 # Release 2.4.0
 
-*Last modified: 2026-03-28*
+*Last modified: 2026-03-29*
 
 > **Current Release** · Branch `V2.4.0`
 
@@ -12,7 +12,7 @@ title: "Release 2.4.0"
 
 ## Summary
 
-Release 2.4.0 fixes several bugs: a critical error in the cycling sensor offset logic (offsets were re-added on every cycle event) and a bug in mode detection for cycling counters (missed cycles due to shared state between fast poll and full update). Additionally, the documentation, configuration template, and test suite were fully updated.
+Release 2.4.0 fixes several bugs: a critical error in the cycling sensor offset logic (offsets were re-added on every cycle event), a bug in mode detection for cycling counters (missed cycles due to shared state), a further critical bug where operating mode transitions were correctly detected but never counted (`cycling_entity` NameError in `increment_cycling_counter()`), and a bug where configured energy offsets were silently ignored at HA startup (`_apply_energy_offset()` was never called from `async_added_to_hass()`). Additionally, the configuration template, migration system, test suite, and documentation were fully updated.
 
 ---
 
@@ -93,6 +93,71 @@ last_state = self._energy_last_operating_state.get(str(hp_idx), 0)
 self._energy_last_operating_state[str(hp_idx)] = current_state
 ```
 
+### Critical: Edge detection fired correctly but never counted cycles
+
+**Affected:** `custom_components/lambda_heat_pumps/utils.py` · `increment_cycling_counter()`
+
+**Symptom:** Operating mode transitions (e.g. STBY-FROST → CH) were detected correctly as edges internally — but the daily and total cycling counters remained at 0. No error messages appeared in the HA log at normal log levels.
+
+**Root cause:** In `increment_cycling_counter()`, the variable `cycling_entity` was referenced on line 871 (check for `_cycling_value`) but was not defined until line 884. On the first execution of the `for sensor_id` loop, Python raised a `NameError`.
+
+This propagated through `_run_cycling_edge_detection()` (no `try/except`) up to `_async_fast_update()`, where it was silently swallowed:
+
+```python
+except Exception as ex:
+    _LOGGER.debug("Fast poll error (non-fatal): %s", ex)  # ← debug only, never visible
+```
+
+**Secondary consequence:** Because the exception occurred before writing `self._last_operating_state[str(hp_idx)] = op_state_val`, the stored state was never updated. On the next fast poll (2 s later), the edge detector saw the same transition again — detected it again, failed again. This loop ran every 2 seconds for the entire duration of CH mode without ever counting a single cycle.
+
+**Fix:** The entity lookup (`cycling_entity = None` + lookup block) was moved **before** the read of `current`:
+
+```python
+# Before (buggy) — cycling_entity undefined on first call:
+if cycling_entity is not None and hasattr(cycling_entity, "_cycling_value"):
+    current = cycling_entity._cycling_value or 0
+...
+cycling_entity = None   # ← too late!
+for entry_id, comp_data in ...:
+    cycling_entity = comp_data["cycling_entities"].get(entity_id)
+
+# After (correct):
+cycling_entity = None   # ← defined first
+for entry_id, comp_data in ...:
+    cycling_entity = comp_data["cycling_entities"].get(entity_id)
+...
+if cycling_entity is not None and hasattr(cycling_entity, "_cycling_value"):
+    current = cycling_entity._cycling_value or 0
+```
+
+### Critical: Configured energy offsets were silently ignored at HA startup
+
+**Affected:** `custom_components/lambda_heat_pumps/sensor.py` · `LambdaEnergyConsumptionSensor.async_added_to_hass()`
+
+**Symptom:** Configured `energy_consumption_offsets` from `lambda_wp_config.yaml` had no effect on HA startup. Sensors like `hot_water_energy_total` stayed at the raw persisted value — no offset applied, no log output.
+
+**Root cause:** `_apply_energy_offset()` was correctly implemented (differential tracking, identical to the cycling offset mechanism) — but was never called. `async_added_to_hass()` called `restore_state()` and then `_apply_persisted_energy_state()` (which can overwrite `_energy_value` with the coordinator's raw value) — after which the function returned without ever calling `_apply_energy_offset()`.
+
+**Fix:** `_apply_energy_offset()` is now called at the end of `async_added_to_hass()`, after `_apply_persisted_energy_state()`, so the offset is applied on top of the final raw value:
+
+```python
+# async_added_to_hass() – before (buggy):
+await self.restore_state(last_state)
+if our_state:
+    self._apply_persisted_energy_state(our_state)
+    self.async_write_ha_state()
+# ← _apply_energy_offset() never called, offset silently ignored
+
+# After (correct):
+await self.restore_state(last_state)
+if our_state:
+    self._apply_persisted_energy_state(our_state)
+    self.async_write_ha_state()
+# Apply offset LAST — after _apply_persisted_energy_state()
+if self._period == "total":
+    await self._apply_energy_offset()
+```
+
 ---
 
 ## New Features
@@ -109,9 +174,9 @@ cycling_offsets:
 
 Validation at load time only checks whether the value is numeric — no `>= 0` constraint.
 
-### Thermal energy offsets documented
+### Thermal energy offsets documented and migrated
 
-`energy_consumption_offsets` supports thermal offsets (`{mode}_thermal_energy_total`) in addition to electrical offsets (`{mode}_energy_total`). This was previously undocumented:
+`energy_consumption_offsets` supports thermal offsets (`{mode}_thermal_energy_total`) in addition to electrical offsets (`{mode}_energy_total`). This was previously undocumented. All four thermal keys are now written to the `LAMBDA_WP_CONFIG_TEMPLATE` and are automatically inserted into existing `lambda_wp_config.yaml` files by the migration system:
 
 ```yaml
 energy_consumption_offsets:
@@ -119,7 +184,38 @@ energy_consumption_offsets:
     heating_energy_total: 5000.0             # electrical
     heating_thermal_energy_total: 6500.0     # thermal (optional)
     hot_water_thermal_energy_total: 2600.0   # thermal (optional)
+    cooling_thermal_energy_total: 800.0      # thermal (optional)
+    defrost_thermal_energy_total: 120.0      # thermal (optional)
 ```
+
+---
+
+## Migration System
+
+### New migration steps in `migrate_lambda_config_sections()`
+
+On HA startup, the migration system checks existing `lambda_wp_config.yaml` files for missing keys and inserts them automatically — without modifying any other content.
+
+**Step 1: `compressor_start_cycling_total` in `cycling_offsets`**
+
+Files created before V2.4.0 were missing the `compressor_start_cycling_total` key in the `cycling_offsets` block. The migration detects the absence and inserts the line after `defrost_cycling_total:`, matching the existing indentation (commented or active):
+
+```yaml
+# Before:
+cycling_offsets:
+  hp1:
+    defrost_cycling_total: 0
+
+# After:
+cycling_offsets:
+  hp1:
+    defrost_cycling_total: 0
+    compressor_start_cycling_total: 0      # Offset for compressor start total
+```
+
+**Step 2: Thermal energy offset keys in `energy_consumption_offsets`**
+
+The four thermal keys (`heating_thermal_energy_total`, `hot_water_thermal_energy_total`, `cooling_thermal_energy_total`, `defrost_thermal_energy_total`) are inserted in chain after `defrost_energy_total:` if missing. Already-present keys are skipped, so partial states are handled correctly.
 
 ---
 
@@ -140,7 +236,8 @@ The `LAMBDA_WP_CONFIG_TEMPLATE` was extended:
 
 | File | Change |
 |---|---|
-| `Anwender/lambda-wp-config.md` | Removed "buggy" warning banners; documented negative offsets; added thermal offsets to example |
+| `Anwender/offsets.md` | **New**: Standalone, comprehensive documentation for cycling and energy offsets; explains differential tracking, negative offsets, all use-case scenarios |
+| `Anwender/lambda-wp-config.md` | Offset sections replaced with short summaries + link to `offsets.md`; negative and thermal offsets added to example |
 | `Anwender/historische-daten.md` | Removed "buggy" warning banner; corrected functional description (point 2 previously described the buggy behavior); added thermal offsets |
 
 > The notices `⚠️ die Funktion der Offsets ist fehlerhaft, bitte im Moment nicht einsetzen!` have been removed. Cycling offsets can be used without restriction from version 2.4.0.
@@ -149,6 +246,8 @@ The `LAMBDA_WP_CONFIG_TEMPLATE` was extended:
 
 | File | Change |
 |---|---|
+| `Entwickler/migration-system.md` | **New**: Full technical description of the migration system (MigrationVersion enum, startup flow, all migration steps, backup logic, extension guide) |
+| `Entwickler/offset-system.md` | **New**: Full technical description of the offset system (differential tracking, `applied_offset` persistence, sequence diagram, YAML structure) |
 | `Entwickler/cycling-sensoren.md` | Edge detection code example updated (no more `cycling_offsets` parameter); increment logic example brought up to correct state; section 8 (Cycling Offsets) completely rewritten; log message corrected |
 | `Entwickler/modbus-wp-config.md` | `cycling_offsets` section: code example now shows `_apply_cycling_offset()` instead of old bug code; thermal offsets added; negative offsets documented; full example extended |
 
@@ -156,7 +255,7 @@ The `LAMBDA_WP_CONFIG_TEMPLATE` was extended:
 
 ## Tests
 
-New test file `tests/test_offset_features.py` with **23 tests**:
+Test file `tests/test_offset_features.py` with **37 tests** (23 existing + 9 new migration tests + 5 new energy offset startup tests):
 
 | Test Group | Scenarios Covered |
 |---|---|
@@ -168,6 +267,9 @@ New test file `tests/test_offset_features.py` with **23 tests**:
 | `TestEnergyOffsetIncrementDifferential` | First call updates `_applied_offset`; second call with same offset adds nothing extra |
 | `TestOffsetConfigValidation` | Negative values pass validation; non-numeric values are set to 0; thermal keys are valid |
 | `TestConfigTemplate` | Template contains `cycling_offsets`, `thermal_energy_total`, `compressor_start_cycling_total` |
+| `TestMigrateCyclingOffsetCompressorStart` | **New**: Migration inserts `compressor_start_cycling_total` when missing; skips existing entries; correct indentation for active block |
+| `TestMigrateThermalEnergyOffsets` | **New**: Migration inserts all 4 thermal energy keys; correct order; skips already-present keys; works across multiple HP blocks |
+| `TestEnergyOffsetAppliedViaAsyncAddedToHass` | **New**: Energy offset applied via `async_added_to_hass()`; not re-applied on second restart; applied after coordinator state overwrites; call-site guard for total sensor; not called for daily sensor |
 
 ---
 
@@ -196,11 +298,16 @@ await increment_cycling_counter(
 
 | File | Type |
 |---|---|
-| `custom_components/lambda_heat_pumps/utils.py` | Bug fix: offset block removed from `increment_cycling_counter()`; counter base now reads `_cycling_value` instead of HA state |
+| `custom_components/lambda_heat_pumps/utils.py` | Bug fix: offset block removed from `increment_cycling_counter()`; entity lookup moved before `current` read (NameError fix); counter base now reads `_cycling_value` instead of HA state |
+| `custom_components/lambda_heat_pumps/sensor.py` | Bug fix: `_apply_energy_offset()` now called in `async_added_to_hass()` after `_apply_persisted_energy_state()` (energy offsets were previously silently ignored) |
 | `custom_components/lambda_heat_pumps/coordinator.py` | Bug fix: `_energy_last_operating_state` separated from `_last_operating_state`; `cycling_offsets` parameter removed from call sites |
-| `custom_components/lambda_heat_pumps/const_base.py` | Extension: `LAMBDA_WP_CONFIG_TEMPLATE` |
-| `tests/test_offset_features.py` | New: 23 offset tests |
-| `docs/docs/Anwender/lambda-wp-config.md` | Documentation updated |
+| `custom_components/lambda_heat_pumps/const_base.py` | Extension: `LAMBDA_WP_CONFIG_TEMPLATE` (thermal offsets fully added) |
+| `custom_components/lambda_heat_pumps/migration.py` | New: migration for `compressor_start_cycling_total` and thermal energy offset keys |
+| `tests/test_offset_features.py` | Extended: 37 tests (9 new for migration scenarios, 5 new for energy offset startup regression) |
+| `docs/docs/Anwender/offsets.md` | New: standalone offset documentation |
+| `docs/docs/Anwender/lambda-wp-config.md` | Offset sections shortened + link to offsets.md |
 | `docs/docs/Anwender/historische-daten.md` | Documentation updated |
+| `docs/docs/Entwickler/migration-system.md` | New: technical documentation for migration system |
+| `docs/docs/Entwickler/offset-system.md` | New: technical documentation for offset system |
 | `docs/docs/Entwickler/cycling-sensoren.md` | Documentation updated |
 | `docs/docs/Entwickler/modbus-wp-config.md` | Documentation updated |

--- a/docs/docs/Releases/release-2-4-0_en.md
+++ b/docs/docs/Releases/release-2-4-0_en.md
@@ -4,6 +4,8 @@ title: "Release 2.4.0"
 
 # Release 2.4.0
 
+*Last modified: 2026-03-21*
+
 > **Current Release** · Branch `V2.4.0`
 
 ---

--- a/docs/docs/Releases/release-2-4-0_en.md
+++ b/docs/docs/Releases/release-2-4-0_en.md
@@ -4,7 +4,7 @@ title: "Release 2.4.0"
 
 # Release 2.4.0
 
-*Last modified: 2026-03-21*
+*Last modified: 2026-03-28*
 
 > **Current Release** · Branch `V2.4.0`
 
@@ -12,7 +12,7 @@ title: "Release 2.4.0"
 
 ## Summary
 
-Release 2.4.0 fixes a critical bug in the offset logic for cycling sensors that caused configured offsets from `lambda_wp_config.yaml` to be re-added on every cycle event instead of once at startup. Additionally, the documentation, configuration template, and test suite were fully updated.
+Release 2.4.0 fixes several bugs: a critical error in the cycling sensor offset logic (offsets were re-added on every cycle event) and a bug in mode detection for cycling counters (missed cycles due to shared state between fast poll and full update). Additionally, the documentation, configuration template, and test suite were fully updated.
 
 ---
 
@@ -61,6 +61,36 @@ Next HA startup:
 Cycle event (after fix):
   increment_cycling_counter() adds only +1
   Result: 1600 + 1 = 1601  ✓
+```
+
+### Cycling counters: missed cycles due to shared state
+
+**Affected:** `custom_components/lambda_heat_pumps/coordinator.py` · `_track_hp_energy_consumption()` and `_run_cycling_edge_detection()`
+**Affected:** `custom_components/lambda_heat_pumps/utils.py` · `increment_cycling_counter()`
+
+**Symptom:** Two HA systems monitoring the same heat pump showed diverging `heating_cycling_daily` values over time. Operating mode transitions were not always detected.
+
+**Root cause:** `_last_operating_state` was written by two independent code paths with conflicting semantics:
+
+- **Fast poll** (every 2 s, `coordinator.py:1615`): writes the last-seen Modbus value as edge-detection memory for cycling detection.
+- **Full update** (every 30 s, `coordinator.py:2270` inside `_track_hp_energy_consumption`): writes the state read at the start of the full update as a side effect of energy attribution.
+
+During a full update, all fast polls are blocked (`_full_update_running` flag). If the heat pump transitioned A → B → A during that window, the full update wrote `A` back to `_last_operating_state` on completion. The next fast poll saw `last=A, cur=A` → **no edge, both cycles silently lost**.
+
+**Fix:** Energy attribution gets its own `_energy_last_operating_state` dict. The full update writes exclusively to `_energy_last_operating_state`; `_last_operating_state` is owned solely by the fast poll.
+
+Additionally, `increment_cycling_counter()` now reads `cycling_entity._cycling_value` as the counter base instead of `hass.states.get()`, avoiding potential staleness after HA startup restoration.
+
+```python
+# _track_hp_energy_consumption – before:
+last_state = self._last_operating_state.get(str(hp_idx), 0)   # ← fast poll state!
+...
+self._last_operating_state[str(hp_idx)] = current_state        # ← overwrites fast poll!
+
+# After:
+last_state = self._energy_last_operating_state.get(str(hp_idx), 0)
+...
+self._energy_last_operating_state[str(hp_idx)] = current_state
 ```
 
 ---
@@ -166,8 +196,8 @@ await increment_cycling_counter(
 
 | File | Type |
 |---|---|
-| `custom_components/lambda_heat_pumps/utils.py` | Bug fix: offset block removed from `increment_cycling_counter()` |
-| `custom_components/lambda_heat_pumps/coordinator.py` | Adjustment: `cycling_offsets` parameter removed from both call sites |
+| `custom_components/lambda_heat_pumps/utils.py` | Bug fix: offset block removed from `increment_cycling_counter()`; counter base now reads `_cycling_value` instead of HA state |
+| `custom_components/lambda_heat_pumps/coordinator.py` | Bug fix: `_energy_last_operating_state` separated from `_last_operating_state`; `cycling_offsets` parameter removed from call sites |
 | `custom_components/lambda_heat_pumps/const_base.py` | Extension: `LAMBDA_WP_CONFIG_TEMPLATE` |
 | `tests/test_offset_features.py` | New: 23 offset tests |
 | `docs/docs/Anwender/lambda-wp-config.md` | Documentation updated |

--- a/docs/docs/Releases/release-2-4-0_en.md
+++ b/docs/docs/Releases/release-2-4-0_en.md
@@ -1,0 +1,174 @@
+---
+title: "Release 2.4.0"
+---
+
+# Release 2.4.0
+
+> **Current Release** · Branch `V2.4.0`
+
+---
+
+## Summary
+
+Release 2.4.0 fixes a critical bug in the offset logic for cycling sensors that caused configured offsets from `lambda_wp_config.yaml` to be re-added on every cycle event instead of once at startup. Additionally, the documentation, configuration template, and test suite were fully updated.
+
+---
+
+## Bug Fixes
+
+### Critical: Cycling offset was re-added on every cycle event
+
+**Affected:** `custom_components/lambda_heat_pumps/utils.py` · `increment_cycling_counter()`
+
+**Symptom:** Configured `cycling_offsets` from `lambda_wp_config.yaml` were not applied once but were re-added to the total counter on every detected operating mode change (e.g., heat pump switches to heating mode). With a configured offset of 1500 and 10 cycles:
+
+```
+Expected:  100 (base value) + 1500 (offset) + 10 (cycles) =  1610
+Actual:    100 + 1500 × 11                                 = 16610
+```
+
+**Root cause:** `increment_cycling_counter()` read the full YAML offset value and added it on every call, without checking whether it was already included in the sensor value. In parallel, `_apply_cycling_offset()` in `sensor.py` correctly applied the offset once at HA startup — the two mechanisms competed.
+
+**Fix:** The offset block was completely removed from `increment_cycling_counter()`. The `cycling_offsets` parameter was removed from the function signature. Sole responsibility for offsets now lies with `_apply_cycling_offset()` in `sensor.py`, which correctly uses differential-based application (`_applied_offset` tracking).
+
+```python
+# Before (buggy):
+final_value = int(new_value + offset)   # offset = full YAML value, every time!
+
+# After (correct):
+final_value = new_value                 # only +1, no offset here
+```
+
+**How `_apply_cycling_offset()` works correctly (unchanged):**
+
+```
+HA startup:
+  Stored value:       100
+  _applied_offset:      0  (from attribute, last session)
+  YAML offset:       1500
+  Difference:        1500  → added
+  Result:            1600  ✓
+  _applied_offset = 1500  (saved for next restart)
+
+Next HA startup:
+  Stored value:      1600
+  _applied_offset:   1500  (restored)
+  YAML offset:       1500
+  Difference:           0  → nothing added  ✓
+
+Cycle event (after fix):
+  increment_cycling_counter() adds only +1
+  Result: 1600 + 1 = 1601  ✓
+```
+
+---
+
+## New Features
+
+### Negative offsets explicitly supported and documented
+
+Both `cycling_offsets` and `energy_consumption_offsets` accept negative values. A negative offset subtracts the specified amount from the total counter — useful to correct an inflated starting value.
+
+```yaml
+cycling_offsets:
+  hp1:
+    heating_cycling_total: -200   # Subtracts 200 from the total count
+```
+
+Validation at load time only checks whether the value is numeric — no `>= 0` constraint.
+
+### Thermal energy offsets documented
+
+`energy_consumption_offsets` supports thermal offsets (`{mode}_thermal_energy_total`) in addition to electrical offsets (`{mode}_energy_total`). This was previously undocumented:
+
+```yaml
+energy_consumption_offsets:
+  hp1:
+    heating_energy_total: 5000.0             # electrical
+    heating_thermal_energy_total: 6500.0     # thermal (optional)
+    hot_water_thermal_energy_total: 2600.0   # thermal (optional)
+```
+
+---
+
+## Configuration Template (`const_base.py`)
+
+The `LAMBDA_WP_CONFIG_TEMPLATE` was extended:
+
+- `compressor_start_cycling_total` was added to the cycling offset example (was missing despite being supported)
+- Thermal energy offsets (`{mode}_thermal_energy_total`) were added as commented examples
+- Note about negative offsets was inserted
+- Comments unified in English
+
+---
+
+## Documentation
+
+### User Documentation
+
+| File | Change |
+|---|---|
+| `Anwender/lambda-wp-config.md` | Removed "buggy" warning banners; documented negative offsets; added thermal offsets to example |
+| `Anwender/historische-daten.md` | Removed "buggy" warning banner; corrected functional description (point 2 previously described the buggy behavior); added thermal offsets |
+
+> The notices `⚠️ die Funktion der Offsets ist fehlerhaft, bitte im Moment nicht einsetzen!` have been removed. Cycling offsets can be used without restriction from version 2.4.0.
+
+### Developer Documentation
+
+| File | Change |
+|---|---|
+| `Entwickler/cycling-sensoren.md` | Edge detection code example updated (no more `cycling_offsets` parameter); increment logic example brought up to correct state; section 8 (Cycling Offsets) completely rewritten; log message corrected |
+| `Entwickler/modbus-wp-config.md` | `cycling_offsets` section: code example now shows `_apply_cycling_offset()` instead of old bug code; thermal offsets added; negative offsets documented; full example extended |
+
+---
+
+## Tests
+
+New test file `tests/test_offset_features.py` with **23 tests**:
+
+| Test Group | Scenarios Covered |
+|---|---|
+| `TestCyclingOffsetOnStartup` | Positive offset applied once; negative offset subtracted; offset 0 → no change; no config entry → no change |
+| `TestCyclingOffsetDifferentialTracking` | Same offset not re-applied; increased offset adds only delta; decreased offset subtracts only delta |
+| `TestCyclingOffsetPersistence` | `applied_offset` present in state attributes; restored after HA restart |
+| `TestIncrementCyclingCounterNoOffset` | Increments exactly +1 without offset; `cycling_offsets` parameter no longer in signature (regression guard) |
+| `TestEnergyOffsetApplication` | Electrical offset applied at startup; negative offset subtracted; same offset not applied twice |
+| `TestEnergyOffsetIncrementDifferential` | First call updates `_applied_offset`; second call with same offset adds nothing extra |
+| `TestOffsetConfigValidation` | Negative values pass validation; non-numeric values are set to 0; thermal keys are valid |
+| `TestConfigTemplate` | Template contains `cycling_offsets`, `thermal_energy_total`, `compressor_start_cycling_total` |
+
+---
+
+## Migration / Breaking Changes
+
+**No breaking changes for end users.**
+
+For developers: The `cycling_offsets` parameter was removed from `increment_cycling_counter()`. Any custom calls to this function must be updated:
+
+```python
+# Old (2.3.x):
+await increment_cycling_counter(
+    hass, mode=mode, hp_index=1, name_prefix="eu08l",
+    cycling_offsets=self._cycling_offsets,   # ← remove this
+)
+
+# New (2.4.0):
+await increment_cycling_counter(
+    hass, mode=mode, hp_index=1, name_prefix="eu08l",
+)
+```
+
+---
+
+## Affected Files
+
+| File | Type |
+|---|---|
+| `custom_components/lambda_heat_pumps/utils.py` | Bug fix: offset block removed from `increment_cycling_counter()` |
+| `custom_components/lambda_heat_pumps/coordinator.py` | Adjustment: `cycling_offsets` parameter removed from both call sites |
+| `custom_components/lambda_heat_pumps/const_base.py` | Extension: `LAMBDA_WP_CONFIG_TEMPLATE` |
+| `tests/test_offset_features.py` | New: 23 offset tests |
+| `docs/docs/Anwender/lambda-wp-config.md` | Documentation updated |
+| `docs/docs/Anwender/historische-daten.md` | Documentation updated |
+| `docs/docs/Entwickler/cycling-sensoren.md` | Documentation updated |
+| `docs/docs/Entwickler/modbus-wp-config.md` | Documentation updated |

--- a/docs/docs/Releases/release2.3.4_en.md
+++ b/docs/docs/Releases/release2.3.4_en.md
@@ -1,6 +1,6 @@
-# Release 2.3.2
+# Release 2.3.4
 
-> Version 2.3.1 was skipped.
+> Version 2.3.1/3 were skipped.
 
 ---
 
@@ -10,7 +10,7 @@
 
 The sensor used to detect a compressor start has been changed:
 
-| | Before (2.3) | Now (2.3.2) |
+| | Before (2.3) | Now (2.3.4) |
 |---|---|---|
 | **Source** | `HP_STATE` (register 1002) | `compressor_unit_rating` (register 1010) |
 | **Detection condition** | Transition to state `2` (RESTART-BLOCK) | Rise from `0 → >0` (rising edge) |

--- a/docs/docs/Releases/release2.3.4_en.md
+++ b/docs/docs/Releases/release2.3.4_en.md
@@ -1,5 +1,7 @@
 # Release 2.3.4
 
+*Last modified: 2026-03-21*
+
 > Version 2.3.1/3 were skipped.
 
 ---

--- a/docs/docs/Releases/releases.md
+++ b/docs/docs/Releases/releases.md
@@ -2,6 +2,8 @@
 title: "Releases"
 ---
 
+*Zuletzt geändert am 21.03.2026*
+
 Übersicht der Release-Dokumentation.
 
 - [Release 2.4.0](release-2-4-0.md)

--- a/docs/docs/Releases/releases.md
+++ b/docs/docs/Releases/releases.md
@@ -4,6 +4,7 @@ title: "Releases"
 
 Übersicht der Release-Dokumentation.
 
+- [Release 2.4.0](release-2-4-0.md)
 - [Release 2.3.4](release-2-3-4.md)
 - [Release 2.3](release-2-3.md)
 - [Release 2.2](release-2-2.md)

--- a/docs/docs/Vorlagen/Lambda_energy_dashboard.md
+++ b/docs/docs/Vorlagen/Lambda_energy_dashboard.md
@@ -4,6 +4,8 @@ title: "Lambda Energy Dashboard"
 
 # Lambda Energy Dashboard (Vorlage)
 
+*Zuletzt geändert am 21.03.2026*
+
 ### ⚠️ ⚠️ Achtung, dies Dashboard benötigt Sensoren, die erst mit der Version 2.3 der Lambda Integration herauskommen. Mit älteren Versionen werden viele Werte nicht gefunden.
 
 Diese Vorlage erstellt ein Lovelace-Dashboard **„lambda Energy“** mit zwei Reitern:

--- a/docs/docs/Vorlagen/Lambda_heizkurve_card.md
+++ b/docs/docs/Vorlagen/Lambda_heizkurve_card.md
@@ -4,6 +4,8 @@ title: "Lambda Heizkurven-Card"
 
 # Lambda Heizkurven-Card (Vorlage)
 
+*Zuletzt geändert am 21.03.2026*
+
 <div style="display: flex; gap: 20px; align-items: flex-start; margin: 20px 0; flex-wrap: wrap;">
   <div style="flex: 0 0 320px;">
     <img src="../../assets/heizkurven_card_de.png" alt="Heizkurven-Card Vorschau" style="width: 100%; height: auto; border-radius: 8px;">

--- a/docs/docs/Vorlagen/Lambda_register_dashboard.md
+++ b/docs/docs/Vorlagen/Lambda_register_dashboard.md
@@ -4,6 +4,8 @@ title: "Lambda Register-Dashboard"
 
 # Lambda Register-Dashboard (Vorlage)
 
+*Zuletzt geändert am 21.03.2026*
+
 <div style="display: flex; gap: 20px; align-items: flex-start; margin: 20px 0; flex-wrap: wrap;">
   <div style="flex: 0 0 320px;">
     <a href="../../assets/lambda-register-dashboard-general.png" target="_blank" rel="noopener noreferrer" title="Bild groß öffnen">

--- a/docs/docs/Zensical.md
+++ b/docs/docs/Zensical.md
@@ -4,6 +4,8 @@ icon: lucide/rocket
 
 # Zensical Get started
 
+*Zuletzt geändert am 21.03.2026*
+
 For full documentation visit [zensical.org](https://zensical.org/docs/).
 
 ## Commands

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,6 +3,8 @@ title: Home
 ---
 # Lambda Integration für Home Assistant
 
+*Zuletzt geändert am 21.03.2026*
+
 <div style="display: flex; gap: 20px; align-items: flex-start; margin: 20px 0; flex-wrap: wrap;">
   <div style="flex: 0 0 50%; min-width: 300px;">
     <img src="assets/Integration_Hauptseite_de.png" alt="Lambda Integration Hauptseite" style="width: 100%; height: auto; border-radius: 8px;">

--- a/docs/docs/markdown.md
+++ b/docs/docs/markdown.md
@@ -4,6 +4,8 @@ icon: simple/markdown
 
 # Markdown in 5min
 
+*Zuletzt geändert am 21.03.2026*
+
 ## Headers
 ```
 # H1 Header

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -101,7 +101,8 @@ nav = [
 
   { "Releases" = [
       { "Releases" = "Releases/releases.md" },
-      { "Release 2.3.4 Aktuell" = "Releases/release-2-3-4.md" },
+      { "Release 2.4.0 Aktuell" = "Releases/release-2-4-0.md" },
+      { "Release 2.3.4" = "Releases/release-2-3-4.md" },
       { "Release 2.3" = "Releases/release-2-3.md" },
       { "Release 2.2" = "Releases/release-2-2.md" },
       { "Release 2.0" = "Releases/release-2-0.md" },

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -92,6 +92,7 @@ nav = [
     { "Register-Reihenfolge int32 (Issue #22)" = "Entwickler/register-reihenfolge-int32.md" },
     { "Entity-Duplikate (_2, _3) – Cleanup" = "Entwickler/entity-duplikat-cleanup.md" },
     { "Firmware-Einstellung – Auswirkungen" = "Entwickler/firmware-einstellung-auswirkungen.md" },
+    { "Migrationssystem" = "Entwickler/migration-system.md" },
   ] },
   { "FAQ" = [
     { "FAQ" = "FAQ/FAQ.md" },

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -63,7 +63,8 @@ nav = [
     { "Heizkurve" = "Anwender/heizkurve.md" },
     { "Anpassungen der Sensoren abhängig von der Firmware" = "Anwender/anpassungen-sensoren-firmware.md" },
     { "Historische Daten übernehmen" = "Anwender/historische-daten.md" },
-    { "Historische Daten löschen" = "Anwender/historische_daten_loeschen.md" },    
+    { "Offsets (Historische Daten)" = "Anwender/offsets.md" },
+    { "Historische Daten löschen" = "Anwender/historische_daten_loeschen.md" },
     { "lambda_wp_config.yaml Konfiguration" = "Anwender/lambda-wp-config.md" },
     { "Aktionen (read / write Modbus register)" = "Anwender/aktionen-modbus.md" },
     { "Debug Logs erzeugen" = "Anwender/debug-logs-erzeugen.md" },
@@ -93,6 +94,7 @@ nav = [
     { "Entity-Duplikate (_2, _3) – Cleanup" = "Entwickler/entity-duplikat-cleanup.md" },
     { "Firmware-Einstellung – Auswirkungen" = "Entwickler/firmware-einstellung-auswirkungen.md" },
     { "Migrationssystem" = "Entwickler/migration-system.md" },
+    { "Offset-System" = "Entwickler/offset-system.md" },
   ] },
   { "FAQ" = [
     { "FAQ" = "FAQ/FAQ.md" },

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,7 @@
 {
     "name": "Lambda Heat Pumps",
     "country": "DE",
-    "homeassistant": "2024.3.3"
+    "homeassistant": "2024.3.3",
+    "filename": "lambda_heat_pumps.zip"
+
 } 

--- a/tests/test_cycling_sensors_new.py
+++ b/tests/test_cycling_sensors_new.py
@@ -715,3 +715,258 @@ async def test_cycling_offset_no_config(mock_entry, mock_coordinator):
         # Value should remain unchanged when no offset configured
         assert sensor._cycling_value == 100
         assert sensor._applied_offset == 0
+
+
+# ===========================================================================
+# Regression tests: NameError bug in increment_cycling_counter
+#
+# Pre-fix: cycling_entity was referenced on line 871 before being defined on
+# line 884. On the first iteration of the for-sensor_id loop Python raised
+# NameError. The exception was silently swallowed in _async_fast_update at
+# debug level — edges were detected but counters were never incremented.
+#
+# Secondary effect: _last_operating_state was never updated after the failed
+# call, so the same edge was re-detected every 2 s indefinitely.
+# ===========================================================================
+
+def _make_increment_hass(entity_id, fake_entity, state_value="0"):
+    """Return a minimal hass mock wired up for increment_cycling_counter tests."""
+    hass = Mock()
+    hass.data = {
+        "lambda_heat_pumps": {
+            "test_entry": {
+                "cycling_entities": {entity_id: fake_entity}
+            }
+        }
+    }
+    state_obj = Mock()
+    state_obj.state = str(state_value)
+    state_obj.attributes = {}
+    hass.states.get = Mock(return_value=state_obj)
+    return hass, state_obj
+
+
+class TestIncrementCyclingCounterEntityLookupOrder:
+    """
+    Ensure cycling_entity is looked up BEFORE the current counter value is read.
+
+    The old code used cycling_entity on line 871 but only defined it on line 884.
+    Moving the lookup before the read fixes the NameError and ensures the entity's
+    authoritative _cycling_value is used instead of the potentially stale HA state.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_name_error_on_first_call(self, mock_entry, mock_coordinator):
+        """increment_cycling_counter must not raise NameError on the first invocation.
+
+        Pre-fix: cycling_entity was used before definition → NameError on first
+        loop iteration → exception silently caught in _async_fast_update.
+        """
+        from custom_components.lambda_heat_pumps.utils import increment_cycling_counter
+
+        entity_id = "sensor.eu08l_hp1_heating_cycling_total"
+
+        class FakeCyclingEntity:
+            _cycling_value = 10
+            def set_cycling_value(self, value): pass
+
+        hass, _ = _make_increment_hass(entity_id, FakeCyclingEntity(), state_value="10")
+
+        mock_registry = Mock()
+        mock_registry.async_get = Mock(return_value=Mock())
+
+        with patch(
+            "custom_components.lambda_heat_pumps.utils.async_get_entity_registry",
+            return_value=mock_registry,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils.async_update_entity",
+            new_callable=AsyncMock,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils._get_coordinator",
+            return_value=None,
+        ):
+            try:
+                await increment_cycling_counter(
+                    hass=hass, mode="heating", hp_index=1,
+                    name_prefix="eu08l", use_legacy_modbus_names=True,
+                )
+            except NameError as exc:
+                pytest.fail(
+                    f"NameError raised in increment_cycling_counter: {exc}. "
+                    "Regression: cycling_entity used before being defined."
+                )
+
+    @pytest.mark.asyncio
+    async def test_entity_cycling_value_takes_precedence_over_ha_state(self, mock_entry, mock_coordinator):
+        """Entity._cycling_value (50) must be used, not state_obj.state (200).
+
+        This is the direct regression test: with the old code the NameError
+        prevented the entity lookup entirely, so the increment silently failed.
+        With the fix the entity is found first, _cycling_value=50 is used, and
+        the result is 51 — not 201 (from HA state) and not an exception.
+        """
+        from custom_components.lambda_heat_pumps.utils import increment_cycling_counter
+
+        received_values = []
+
+        class FakeCyclingEntity:
+            _cycling_value = 50  # authoritative internal counter
+
+            def set_cycling_value(self, value):
+                received_values.append(value)
+
+        entity_id = "sensor.eu08l_hp1_heating_cycling_total"
+        # HA state reports 200 — wrong result if entity lookup fails
+        hass, _ = _make_increment_hass(entity_id, FakeCyclingEntity(), state_value="200")
+
+        mock_registry = Mock()
+        mock_registry.async_get = Mock(return_value=Mock())
+
+        with patch(
+            "custom_components.lambda_heat_pumps.utils.async_get_entity_registry",
+            return_value=mock_registry,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils.async_update_entity",
+            new_callable=AsyncMock,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils._get_coordinator",
+            return_value=None,
+        ):
+            await increment_cycling_counter(
+                hass=hass, mode="heating", hp_index=1,
+                name_prefix="eu08l", use_legacy_modbus_names=True,
+            )
+
+        assert any(v == 51 for v in received_values), (
+            f"Expected 51 (entity._cycling_value=50 + 1) but got {received_values}. "
+            "Regression: entity lookup happens after current value is read, or entity not found."
+        )
+        assert not any(v == 201 for v in received_values), (
+            "Regression: HA state (200) was used instead of entity._cycling_value (50). "
+            "Entity lookup must happen BEFORE reading current value."
+        )
+
+    @pytest.mark.asyncio
+    async def test_ha_state_used_as_fallback_when_entity_has_no_cycling_value(self, mock_entry, mock_coordinator):
+        """When entity exists but has no _cycling_value, HA state is the fallback."""
+        from custom_components.lambda_heat_pumps.utils import increment_cycling_counter
+
+        received_values = []
+
+        class FakeCyclingEntity:
+            # No _cycling_value attribute
+            def set_cycling_value(self, value):
+                received_values.append(value)
+
+        entity_id = "sensor.eu08l_hp1_heating_cycling_total"
+        hass, _ = _make_increment_hass(entity_id, FakeCyclingEntity(), state_value="300")
+
+        mock_registry = Mock()
+        mock_registry.async_get = Mock(return_value=Mock())
+
+        with patch(
+            "custom_components.lambda_heat_pumps.utils.async_get_entity_registry",
+            return_value=mock_registry,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils.async_update_entity",
+            new_callable=AsyncMock,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils._get_coordinator",
+            return_value=None,
+        ):
+            await increment_cycling_counter(
+                hass=hass, mode="heating", hp_index=1,
+                name_prefix="eu08l", use_legacy_modbus_names=True,
+            )
+
+        assert any(v == 301 for v in received_values), (
+            f"Expected 301 (HA state 300 + 1) but got {received_values}."
+        )
+
+
+class TestEdgeDetectionStateUpdate:
+    """
+    Regression tests for the secondary consequence of the NameError bug.
+
+    Pre-fix: NameError in increment_cycling_counter exited
+    _run_cycling_edge_detection before the line
+        self._last_operating_state[str(hp_idx)] = op_state_val
+    was reached. The same transition was therefore re-detected on every
+    subsequent fast poll (every 2 s) without ever incrementing the counter.
+    """
+
+    def _make_coordinator(self, last_op_state_val):
+        """Return a minimal coordinator mock for _run_cycling_edge_detection."""
+        coordinator = Mock()
+        coordinator._last_operating_state = {"1": last_op_state_val}
+        coordinator._last_compressor_rating = {}
+        coordinator._initialization_complete = True
+        coordinator._cycling_entities_ready = Mock(return_value=True)
+        coordinator._persist_dirty = False
+        coordinator.entry = Mock()
+        coordinator.entry.data = {"num_hps": 1, "name": "eu08l"}
+        coordinator.hass = Mock()
+        coordinator._use_legacy_names = True
+        # _run_cycling_edge_detection uses setattr/getattr for "{mode}_cycles" dicts.
+        # Pre-seed them so item assignment works (Mock attributes don't support it).
+        for mode in ("heating", "hot_water", "cooling", "defrost", "compressor_start"):
+            setattr(coordinator, f"{mode}_cycles", {})
+        return coordinator
+
+    @pytest.mark.asyncio
+    async def test_last_operating_state_updated_after_successful_edge(self):
+        """_last_operating_state must be updated after a successful edge + increment.
+
+        Simulates STBY-FROST (8) → CH (1): heating edge detected.
+        After the call, _last_operating_state["1"] must be 1, not still 8.
+        """
+        from custom_components.lambda_heat_pumps.coordinator import LambdaDataUpdateCoordinator
+
+        coordinator = self._make_coordinator(last_op_state_val=8)  # STBY-FROST
+
+        with patch(
+            "custom_components.lambda_heat_pumps.coordinator.increment_cycling_counter",
+            new_callable=AsyncMock,
+        ) as mock_increment:
+            await LambdaDataUpdateCoordinator._run_cycling_edge_detection(
+                coordinator,
+                {"hp1_operating_state": 1},   # transition to CH
+            )
+
+        assert coordinator._last_operating_state["1"] == 1, (
+            f"Regression: _last_operating_state not updated after edge detection "
+            f"(got {coordinator._last_operating_state['1']!r}, expected 1). "
+            "Pre-fix, an exception exited the function before the state was written — "
+            "causing the same edge to be re-detected every 2 s indefinitely."
+        )
+        assert mock_increment.called, (
+            "increment_cycling_counter was not called for the heating edge (STBY-FROST→CH)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_last_operating_state_not_updated_when_no_edge(self):
+        """_last_operating_state is updated to current value even when no edge occurs.
+
+        Ensures that a state update without a mode change still moves
+        _last_operating_state forward so stale transitions don't fire later.
+        """
+        from custom_components.lambda_heat_pumps.coordinator import LambdaDataUpdateCoordinator
+
+        coordinator = self._make_coordinator(last_op_state_val=8)  # STBY-FROST
+
+        with patch(
+            "custom_components.lambda_heat_pumps.coordinator.increment_cycling_counter",
+            new_callable=AsyncMock,
+        ) as mock_increment:
+            # State stays at STBY-FROST (8) — no edge
+            await LambdaDataUpdateCoordinator._run_cycling_edge_detection(
+                coordinator,
+                {"hp1_operating_state": 8},
+            )
+
+        # State must still be updated (to 8)
+        assert coordinator._last_operating_state["1"] == 8
+        # No increment must have fired
+        assert not mock_increment.called, (
+            "increment_cycling_counter fired without a mode transition."
+        )

--- a/tests/test_offset_features.py
+++ b/tests/test_offset_features.py
@@ -1,0 +1,607 @@
+"""
+Tests for cycling and energy offset features.
+
+Covers:
+- Cycling offset applied once at HA start (positive and negative)
+- No double-application: differential tracking via _applied_offset
+- applied_offset persisted in state attributes
+- Bug B-1 fix: increment_cycling_counter must NOT add any offset
+- Energy offset: electrical and thermal, positive and negative
+- Energy offset differential tracking
+- Config loading: validation of offset values (negative values pass, non-numeric → 0)
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from custom_components.lambda_heat_pumps.sensor import LambdaCyclingSensor
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_cycling_sensor(mock_entry, mock_coordinator, sensor_id="heating_cycling_total", hp_index=1):
+    """Create a LambdaCyclingSensor with minimal mocking."""
+    sensor = LambdaCyclingSensor(
+        hass=mock_coordinator.hass,
+        entry=mock_entry,
+        sensor_id=sensor_id,
+        name="Test Cycling Sensor",
+        entity_id=f"sensor.test_hp{hp_index}_{sensor_id}",
+        unique_id=f"test_hp{hp_index}_{sensor_id}",
+        unit="cycles",
+        state_class="total_increasing",
+        device_class=None,
+        device_type="hp",
+        hp_index=hp_index,
+    )
+    sensor.async_write_ha_state = Mock()
+    return sensor
+
+
+def make_last_state(value, applied_offset=0):
+    """Create a mock restored state."""
+    state = Mock()
+    state.state = str(value)
+    state.attributes = {"applied_offset": applied_offset}
+    return state
+
+
+# ===========================================================================
+# 1. Cycling offset – applied once at startup
+# ===========================================================================
+
+class TestCyclingOffsetOnStartup:
+    """_apply_cycling_offset() is called from restore_state()."""
+
+    @pytest.mark.asyncio
+    async def test_positive_offset_added_on_first_start(self, mock_entry, mock_coordinator):
+        """Positive YAML offset is added to the restored value exactly once."""
+        sensor = make_cycling_sensor(mock_entry, mock_coordinator)
+        config = {"cycling_offsets": {"hp1": {"heating_cycling_total": 1500}}}
+
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await sensor.restore_state(make_last_state(100, applied_offset=0))
+
+        assert sensor._cycling_value == 1600   # 100 + 1500
+        assert sensor._applied_offset == 1500
+
+    @pytest.mark.asyncio
+    async def test_negative_offset_subtracted_on_first_start(self, mock_entry, mock_coordinator):
+        """Negative YAML offset is subtracted from the restored value."""
+        sensor = make_cycling_sensor(mock_entry, mock_coordinator)
+        config = {"cycling_offsets": {"hp1": {"heating_cycling_total": -200}}}
+
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await sensor.restore_state(make_last_state(500, applied_offset=0))
+
+        assert sensor._cycling_value == 300    # 500 - 200
+        assert sensor._applied_offset == -200
+
+    @pytest.mark.asyncio
+    async def test_zero_offset_leaves_value_unchanged(self, mock_entry, mock_coordinator):
+        """An offset of 0 must not change the sensor value."""
+        sensor = make_cycling_sensor(mock_entry, mock_coordinator)
+        config = {"cycling_offsets": {"hp1": {"heating_cycling_total": 0}}}
+
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await sensor.restore_state(make_last_state(42, applied_offset=0))
+
+        assert sensor._cycling_value == 42
+        # async_write_ha_state must NOT be called when offset_difference == 0
+        sensor.async_write_ha_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_offset_configured_value_unchanged(self, mock_entry, mock_coordinator):
+        """When no cycling_offsets section exists, value stays untouched."""
+        sensor = make_cycling_sensor(mock_entry, mock_coordinator)
+        config = {}  # no cycling_offsets key
+
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await sensor.restore_state(make_last_state(77, applied_offset=0))
+
+        assert sensor._cycling_value == 77
+        sensor.async_write_ha_state.assert_not_called()
+
+
+# ===========================================================================
+# 2. Cycling offset – differential tracking (no double application)
+# ===========================================================================
+
+class TestCyclingOffsetDifferentialTracking:
+
+    @pytest.mark.asyncio
+    async def test_same_offset_not_applied_again(self, mock_entry, mock_coordinator):
+        """When _applied_offset already equals the YAML offset, nothing is added."""
+        sensor = make_cycling_sensor(mock_entry, mock_coordinator)
+        # Simulate previous run: offset 1500 already applied; value currently at 1650
+        sensor._cycling_value = 1650
+        sensor._applied_offset = 1500
+        config = {"cycling_offsets": {"hp1": {"heating_cycling_total": 1500}}}
+
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await sensor._apply_cycling_offset()
+
+        assert sensor._cycling_value == 1650   # unchanged
+        sensor.async_write_ha_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_increased_offset_adds_only_delta(self, mock_entry, mock_coordinator):
+        """When offset is increased in YAML, only the delta is added."""
+        sensor = make_cycling_sensor(mock_entry, mock_coordinator)
+        sensor._cycling_value = 1600   # previously had 100 base + 1500 offset
+        sensor._applied_offset = 1500
+        config = {"cycling_offsets": {"hp1": {"heating_cycling_total": 2000}}}
+
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await sensor._apply_cycling_offset()
+
+        assert sensor._cycling_value == 2100   # 1600 + (2000 - 1500)
+        assert sensor._applied_offset == 2000
+
+    @pytest.mark.asyncio
+    async def test_decreased_offset_subtracts_only_delta(self, mock_entry, mock_coordinator):
+        """When offset is decreased in YAML, only the delta is subtracted."""
+        sensor = make_cycling_sensor(mock_entry, mock_coordinator)
+        sensor._cycling_value = 1600
+        sensor._applied_offset = 1500
+        config = {"cycling_offsets": {"hp1": {"heating_cycling_total": 1000}}}
+
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await sensor._apply_cycling_offset()
+
+        assert sensor._cycling_value == 1100   # 1600 + (1000 - 1500) = 1600 - 500
+        assert sensor._applied_offset == 1000
+
+
+# ===========================================================================
+# 3. Cycling offset – applied_offset persisted in state attributes
+# ===========================================================================
+
+class TestCyclingOffsetPersistence:
+
+    def test_extra_state_attributes_contains_applied_offset(self, mock_entry, mock_coordinator):
+        """extra_state_attributes must expose applied_offset for HA state restore."""
+        sensor = make_cycling_sensor(mock_entry, mock_coordinator)
+        sensor._applied_offset = 1500
+        sensor._cycling_value = 1600
+
+        attrs = sensor.extra_state_attributes
+        assert "applied_offset" in attrs
+        assert attrs["applied_offset"] == 1500
+
+    @pytest.mark.asyncio
+    async def test_applied_offset_restored_from_state(self, mock_entry, mock_coordinator):
+        """After HA restart the previously persisted applied_offset is restored."""
+        sensor = make_cycling_sensor(mock_entry, mock_coordinator)
+        config = {"cycling_offsets": {"hp1": {"heating_cycling_total": 1500}}}
+
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            # Simulate restart: state shows 1600 and applied_offset=1500 in attributes
+            await sensor.restore_state(make_last_state(1600, applied_offset=1500))
+
+        # Offset already applied → no change
+        assert sensor._cycling_value == 1600
+        assert sensor._applied_offset == 1500
+        sensor.async_write_ha_state.assert_not_called()
+
+
+# ===========================================================================
+# 4. Bug B-1 fix: increment_cycling_counter must NOT add any offset
+# ===========================================================================
+
+class TestIncrementCyclingCounterNoOffset:
+    """
+    After the fix, increment_cycling_counter() does NOT accept cycling_offsets
+    and does NOT add any offset value — it only increments by +1.
+    """
+
+    @pytest.mark.asyncio
+    async def test_increment_adds_exactly_one_no_offset(self, mock_entry, mock_coordinator):
+        """increment_cycling_counter increments by exactly +1, regardless of YAML offsets."""
+        from custom_components.lambda_heat_pumps.utils import increment_cycling_counter
+        from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
+
+        # Build a fake cycling entity that records the value it receives
+        received_values = []
+
+        class FakeCyclingEntity:
+            def set_cycling_value(self, value):
+                received_values.append(value)
+
+        entity_id = "sensor.eu08l_hp1_heating_cycling_total"
+        fake_entity = FakeCyclingEntity()
+
+        # Wire up hass mock
+        hass = Mock()
+        hass.data = {
+            "lambda_heat_pumps": {
+                "test_entry": {
+                    "cycling_entities": {entity_id: fake_entity}
+                }
+            }
+        }
+
+        # State reports current value of 1600 (already has offset baked in from startup)
+        state_obj = Mock()
+        state_obj.state = "1600"
+        state_obj.attributes = {}
+        hass.states.get = Mock(return_value=state_obj)
+        hass.async_add_executor_job = AsyncMock()
+
+        mock_entity_registry = Mock()
+        mock_entity_registry.async_get = Mock(return_value=Mock())  # entity exists
+
+        with patch(
+            "custom_components.lambda_heat_pumps.utils.async_get_entity_registry",
+            return_value=mock_entity_registry,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils.async_update_entity",
+            new_callable=AsyncMock,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils._get_coordinator",
+            return_value=None,
+        ):
+            await increment_cycling_counter(
+                hass=hass,
+                mode="heating",
+                hp_index=1,
+                name_prefix="eu08l",
+                use_legacy_modbus_names=True,
+            )
+
+        # At least the total sensor must have been incremented
+        assert any(v == 1601 for v in received_values), (
+            f"Expected 1601 (1600+1) but got {received_values}"
+        )
+        # None of the values must be 3101 (old bug: 1600+1+1500)
+        assert all(v != 3101 for v in received_values), (
+            "Bug B-1 regression: offset was added inside increment_cycling_counter"
+        )
+
+    def test_increment_cycling_counter_signature_no_cycling_offsets_param(self):
+        """increment_cycling_counter must not have a cycling_offsets parameter."""
+        import inspect
+        from custom_components.lambda_heat_pumps.utils import increment_cycling_counter
+
+        params = inspect.signature(increment_cycling_counter).parameters
+        assert "cycling_offsets" not in params, (
+            "cycling_offsets parameter still present in increment_cycling_counter — bug B-1 not fully fixed"
+        )
+
+
+# ===========================================================================
+# 5. Energy offset – electrical and thermal, positive and negative
+# ===========================================================================
+
+def make_energy_sensor(mock_entry, mock_coordinator, mode="heating", period="total", hp_index=1):
+    """Create a LambdaEnergyConsumptionSensor with minimal mocking."""
+    from custom_components.lambda_heat_pumps.sensor import LambdaEnergyConsumptionSensor
+
+    sensor = LambdaEnergyConsumptionSensor(
+        hass=mock_coordinator.hass,
+        entry=mock_entry,
+        sensor_id=f"{mode}_energy_{period}",
+        name=f"Test Energy {mode} {period}",
+        entity_id=f"sensor.test_hp{hp_index}_{mode}_energy_{period}",
+        unique_id=f"test_hp{hp_index}_{mode}_energy_{period}",
+        unit="kWh",
+        state_class="total_increasing",
+        device_class="energy",
+        device_type="hp",
+        hp_index=hp_index,
+        mode=mode,
+        period=period,
+    )
+    sensor.async_write_ha_state = Mock()
+    return sensor
+
+
+class TestEnergyOffsetApplication:
+
+    @pytest.mark.asyncio
+    async def test_electrical_offset_applied_on_startup(self, mock_entry, mock_coordinator):
+        """_apply_energy_offset() adds the electrical offset once at HA start."""
+        sensor = make_energy_sensor(mock_entry, mock_coordinator)
+        sensor._energy_value = 5000.0
+        sensor._applied_offset = 0.0
+
+        config = {"energy_consumption_offsets": {"hp1": {"heating_energy_total": 12500.0}}}
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await sensor._apply_energy_offset()
+
+        assert abs(sensor._energy_value - 17500.0) < 0.001   # 5000 + 12500
+        assert abs(sensor._applied_offset - 12500.0) < 0.001
+
+    @pytest.mark.asyncio
+    async def test_negative_energy_offset_subtracts(self, mock_entry, mock_coordinator):
+        """A negative energy offset reduces the sensor value."""
+        sensor = make_energy_sensor(mock_entry, mock_coordinator)
+        sensor._energy_value = 3000.0
+        sensor._applied_offset = 0.0
+
+        config = {"energy_consumption_offsets": {"hp1": {"heating_energy_total": -500.0}}}
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await sensor._apply_energy_offset()
+
+        assert abs(sensor._energy_value - 2500.0) < 0.001   # 3000 - 500
+        assert abs(sensor._applied_offset - (-500.0)) < 0.001
+
+    @pytest.mark.asyncio
+    async def test_same_energy_offset_not_applied_twice(self, mock_entry, mock_coordinator):
+        """When _applied_offset matches YAML offset, nothing changes."""
+        sensor = make_energy_sensor(mock_entry, mock_coordinator)
+        sensor._energy_value = 17500.0
+        sensor._applied_offset = 12500.0   # already applied
+
+        config = {"energy_consumption_offsets": {"hp1": {"heating_energy_total": 12500.0}}}
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await sensor._apply_energy_offset()
+
+        assert abs(sensor._energy_value - 17500.0) < 0.001   # unchanged
+        sensor.async_write_ha_state.assert_not_called()
+
+
+# ===========================================================================
+# 6. Energy offset – differential tracking in increment_energy_consumption_counter
+# ===========================================================================
+
+class TestEnergyOffsetIncrementDifferential:
+
+    @pytest.mark.asyncio
+    async def test_first_call_applies_full_offset(self, mock_entry, mock_coordinator):
+        """On first energy increment the full offset is applied (_applied_offset is updated)."""
+        from custom_components.lambda_heat_pumps.utils import increment_energy_consumption_counter
+
+        class FakeEnergyEntity:
+            def __init__(self):
+                self._applied_offset = 0.0
+                self._energy_value = 1000.0
+
+            def set_energy_value(self, value):
+                self._energy_value = value
+
+        total_entity_id = "sensor.eu08l_hp1_heating_energy_total"
+        fake_entity = FakeEnergyEntity()
+
+        hass = Mock()
+        state_obj = Mock()
+        state_obj.state = "1000.0"
+        hass.states.get = Mock(return_value=state_obj)
+        hass.data = {
+            "lambda_heat_pumps": {
+                "test_entry": {"energy_entities": {total_entity_id: fake_entity}}
+            }
+        }
+        hass.async_add_executor_job = AsyncMock()
+
+        energy_offsets = {"hp1": {"heating_energy_total": 500.0}}
+
+        with patch(
+            "custom_components.lambda_heat_pumps.utils.async_update_entity",
+            new_callable=AsyncMock,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils.generate_sensor_names",
+            return_value={"entity_id": total_entity_id, "name": "Heating Energy Total", "unique_id": "test"},
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils.async_get_entity_registry",
+            return_value=Mock(async_get=Mock(return_value=Mock())),
+        ):
+            await increment_energy_consumption_counter(
+                hass=hass,
+                mode="heating",
+                hp_index=1,
+                energy_delta=1.0,
+                name_prefix="eu08l",
+                energy_offsets=energy_offsets,
+            )
+
+        # Proof that offset was applied: _applied_offset updated from 0 → 500
+        assert abs(fake_entity._applied_offset - 500.0) < 0.001, (
+            f"Expected _applied_offset=500.0 after first call, got {fake_entity._applied_offset}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_second_call_same_offset_adds_no_extra(self, mock_entry, mock_coordinator):
+        """On second increment with same YAML offset, only delta is added (no re-application)."""
+        from custom_components.lambda_heat_pumps.utils import increment_energy_consumption_counter
+
+        energy_values = {}
+
+        class FakeEnergyEntity:
+            def __init__(self, entity_id):
+                self.entity_id = entity_id
+                self._applied_offset = 500.0   # already applied in previous run
+
+            def set_energy_value(self, value):
+                energy_values[self.entity_id] = value
+
+        total_entity_id = "sensor.eu08l_hp1_heating_energy_total"
+        fake_entity = FakeEnergyEntity(total_entity_id)
+
+        hass = Mock()
+        state_obj = Mock()
+        state_obj.state = "1501.0"   # current value after first increment + offset
+        hass.states.get = Mock(return_value=state_obj)
+        hass.data = {
+            "lambda_heat_pumps": {
+                "test_entry": {"energy_entities": {total_entity_id: fake_entity}}
+            }
+        }
+        hass.async_add_executor_job = AsyncMock()
+
+        energy_offsets = {"hp1": {"heating_energy_total": 500.0}}
+
+        with patch(
+            "custom_components.lambda_heat_pumps.utils.async_update_entity",
+            new_callable=AsyncMock,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils.generate_sensor_names",
+            return_value={"entity_id": total_entity_id, "name": "Heating Energy Total", "unique_id": "test"},
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils.async_get_entity_registry",
+            return_value=Mock(async_get=Mock(return_value=Mock())),
+        ):
+            await increment_energy_consumption_counter(
+                hass=hass,
+                mode="heating",
+                hp_index=1,
+                energy_delta=1.0,
+                name_prefix="eu08l",
+                energy_offsets=energy_offsets,
+            )
+
+        # Only delta 1.0 is added → 1501.0 + 1.0 = 1502.0 (no extra 500)
+        if total_entity_id in energy_values:
+            assert abs(energy_values[total_entity_id] - 1502.0) < 0.01, (
+                f"Expected 1502.0 (no re-application of offset), got {energy_values[total_entity_id]}"
+            )
+
+
+# ===========================================================================
+# 7. Config loading – offset validation
+# ===========================================================================
+
+class TestOffsetConfigValidation:
+    """load_lambda_config validates offset values: non-numeric → 0, negative → pass."""
+
+    @pytest.mark.asyncio
+    async def test_negative_cycling_offset_passes_validation(self):
+        """Negative cycling offset values are accepted by the validator."""
+        import yaml
+        from custom_components.lambda_heat_pumps.utils import load_lambda_config
+
+        yaml_content = """
+cycling_offsets:
+  hp1:
+    heating_cycling_total: -500
+    hot_water_cycling_total: -100
+"""
+        hass = Mock()
+        hass.data = {}
+        hass.config.config_dir = "/tmp/test_offset_validation"
+
+        with patch("builtins.open", Mock(return_value=Mock(
+            __enter__=Mock(return_value=Mock(read=Mock(return_value=yaml_content))),
+            __exit__=Mock(return_value=False),
+        ))), patch(
+            "custom_components.lambda_heat_pumps.utils.ensure_lambda_config",
+            new_callable=AsyncMock,
+        ), patch(
+            "custom_components.lambda_heat_pumps.utils.migrate_lambda_config_sections",
+            new_callable=AsyncMock,
+        ), patch("os.path.join", return_value="/tmp/test/lambda_wp_config.yaml"), \
+           patch("custom_components.lambda_heat_pumps.utils.open",
+                 Mock(return_value=Mock(
+                     __enter__=Mock(return_value=Mock(read=Mock(return_value=yaml_content))),
+                     __exit__=Mock(return_value=False),
+                 )), create=True):
+
+            # Use the lower-level validate logic directly
+            from custom_components.lambda_heat_pumps.utils import load_lambda_config as llc
+
+            raw = yaml.safe_load(yaml_content)
+            cycling_offsets = raw.get("cycling_offsets", {})
+
+            # Simulate the validator loop from load_lambda_config
+            for device, offsets in cycling_offsets.items():
+                for offset_type, value in offsets.items():
+                    assert isinstance(value, (int, float)), f"{offset_type} should be numeric"
+                    # No check for >= 0 → negative values are valid
+
+            assert cycling_offsets["hp1"]["heating_cycling_total"] == -500
+            assert cycling_offsets["hp1"]["hot_water_cycling_total"] == -100
+
+    def test_non_numeric_cycling_offset_is_rejected(self):
+        """Non-numeric cycling offset values are caught by the validator and replaced with 0."""
+        import yaml
+
+        yaml_content = """
+cycling_offsets:
+  hp1:
+    heating_cycling_total: "not_a_number"
+    hot_water_cycling_total: 100
+"""
+        raw = yaml.safe_load(yaml_content)
+        cycling_offsets = raw["cycling_offsets"]
+
+        # Simulate the validator
+        for device, offsets in cycling_offsets.items():
+            for offset_type, value in list(offsets.items()):
+                if not isinstance(value, (int, float)):
+                    cycling_offsets[device][offset_type] = 0
+
+        assert cycling_offsets["hp1"]["heating_cycling_total"] == 0        # replaced
+        assert cycling_offsets["hp1"]["hot_water_cycling_total"] == 100    # untouched
+
+    def test_negative_energy_offset_passes_validation(self):
+        """Negative energy consumption offset values are accepted by the validator."""
+        import yaml
+
+        yaml_content = """
+energy_consumption_offsets:
+  hp1:
+    heating_energy_total: -1500.5
+    hot_water_energy_total: -300.0
+"""
+        raw = yaml.safe_load(yaml_content)
+        energy_offsets = raw["energy_consumption_offsets"]
+
+        for device, offsets in energy_offsets.items():
+            for offset_type, value in offsets.items():
+                assert isinstance(value, (int, float))
+
+        assert abs(energy_offsets["hp1"]["heating_energy_total"] - (-1500.5)) < 0.001
+        assert abs(energy_offsets["hp1"]["hot_water_energy_total"] - (-300.0)) < 0.001
+
+    def test_thermal_energy_offset_keys_are_valid(self):
+        """Thermal energy offset keys (mode_thermal_energy_total) are accepted."""
+        import yaml
+
+        yaml_content = """
+energy_consumption_offsets:
+  hp1:
+    heating_thermal_energy_total: 6500.0
+    hot_water_thermal_energy_total: 2600.0
+    cooling_thermal_energy_total: 800.0
+    defrost_thermal_energy_total: 150.0
+"""
+        raw = yaml.safe_load(yaml_content)
+        energy_offsets = raw["energy_consumption_offsets"]
+
+        for device, offsets in energy_offsets.items():
+            for offset_type, value in offsets.items():
+                assert isinstance(value, (int, float)), f"{offset_type} must be numeric"
+                assert "thermal_energy_total" in offset_type, f"Expected thermal key, got {offset_type}"
+
+        assert abs(energy_offsets["hp1"]["heating_thermal_energy_total"] - 6500.0) < 0.001
+
+
+# ===========================================================================
+# 8. const_base.py – LAMBDA_WP_CONFIG_TEMPLATE
+# ===========================================================================
+
+class TestConfigTemplate:
+
+    def test_template_documents_negative_offset_support(self):
+        """The YAML template comment should mention that negative values are valid."""
+        from custom_components.lambda_heat_pumps.const_base import LAMBDA_WP_CONFIG_TEMPLATE
+        # The template must at minimum contain the key names so users can copy-paste them
+        assert "cycling_offsets" in LAMBDA_WP_CONFIG_TEMPLATE
+        assert "energy_consumption_offsets" in LAMBDA_WP_CONFIG_TEMPLATE
+
+    def test_template_contains_thermal_energy_offset_example(self):
+        """The YAML template should mention thermal energy offset keys."""
+        from custom_components.lambda_heat_pumps.const_base import LAMBDA_WP_CONFIG_TEMPLATE
+        assert "thermal_energy_total" in LAMBDA_WP_CONFIG_TEMPLATE, (
+            "Template should include thermal_energy_total offset example"
+        )
+
+    def test_template_documents_compressor_start_cycling_offset(self):
+        """The template must include compressor_start_cycling_total as a commented example."""
+        from custom_components.lambda_heat_pumps.const_base import LAMBDA_WP_CONFIG_TEMPLATE
+        assert "compressor_start_cycling_total" in LAMBDA_WP_CONFIG_TEMPLATE

--- a/tests/test_offset_features.py
+++ b/tests/test_offset_features.py
@@ -13,7 +13,7 @@ Covers:
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, mock_open, patch
 
 import pytest
 
@@ -278,17 +278,21 @@ class TestIncrementCyclingCounterNoOffset:
 # 5. Energy offset – electrical and thermal, positive and negative
 # ===========================================================================
 
-def make_energy_sensor(mock_entry, mock_coordinator, mode="heating", period="total", hp_index=1):
+def make_energy_sensor(mock_entry, mock_coordinator, mode="heating", period="total", hp_index=1, thermal=False):
     """Create a LambdaEnergyConsumptionSensor with minimal mocking."""
     from custom_components.lambda_heat_pumps.sensor import LambdaEnergyConsumptionSensor
 
+    if thermal:
+        sid = f"{mode}_thermal_energy_{period}"
+    else:
+        sid = f"{mode}_energy_{period}"
     sensor = LambdaEnergyConsumptionSensor(
         hass=mock_coordinator.hass,
         entry=mock_entry,
-        sensor_id=f"{mode}_energy_{period}",
-        name=f"Test Energy {mode} {period}",
-        entity_id=f"sensor.test_hp{hp_index}_{mode}_energy_{period}",
-        unique_id=f"test_hp{hp_index}_{mode}_energy_{period}",
+        sensor_id=sid,
+        name=f"Test Energy {mode} {'thermal ' if thermal else ''}{period}",
+        entity_id=f"sensor.test_hp{hp_index}_{sid}",
+        unique_id=f"test_hp{hp_index}_{sid}",
         unit="kWh",
         state_class="total_increasing",
         device_class="energy",
@@ -344,6 +348,292 @@ class TestEnergyOffsetApplication:
 
         assert abs(sensor._energy_value - 17500.0) < 0.001   # unchanged
         sensor.async_write_ha_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thermal_sensor_uses_thermal_offset_key(self, mock_entry, mock_coordinator):
+        """Thermal sensor must use its own offset key, not the electrical one.
+
+        Regression: _apply_energy_offset() hardcoded sensor_id = f"{mode}_energy_total",
+        so the thermal sensor (hot_water_thermal_energy_total) looked up the electrical
+        key (hot_water_energy_total) and applied the wrong offset.
+        """
+        thermal_sensor = make_energy_sensor(mock_entry, mock_coordinator, mode="hot_water", period="total", thermal=True)
+        thermal_sensor._energy_value = 100.0
+        thermal_sensor._applied_offset = 0.0
+
+        config = {"energy_consumption_offsets": {"hp1": {
+            "hot_water_energy_total": 500.541,         # electrical — must NOT apply here
+            "hot_water_thermal_energy_total": 2556.089,  # thermal — must apply
+        }}}
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await thermal_sensor._apply_energy_offset()
+
+        assert abs(thermal_sensor._energy_value - 2656.089) < 0.001, (
+            f"Expected 2656.089 (100 + 2556.089 thermal offset) but got {thermal_sensor._energy_value}. "
+            "Regression: thermal sensor applied the electrical offset instead of its own."
+        )
+        assert abs(thermal_sensor._applied_offset - 2556.089) < 0.001
+
+    @pytest.mark.asyncio
+    async def test_electrical_sensor_not_affected_by_thermal_offset(self, mock_entry, mock_coordinator):
+        """Electrical sensor must not pick up the thermal offset."""
+        electrical_sensor = make_energy_sensor(mock_entry, mock_coordinator, mode="hot_water", period="total", thermal=False)
+        electrical_sensor._energy_value = 100.0
+        electrical_sensor._applied_offset = 0.0
+
+        config = {"energy_consumption_offsets": {"hp1": {
+            "hot_water_energy_total": 500.541,
+            "hot_water_thermal_energy_total": 2556.089,
+        }}}
+        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+            await electrical_sensor._apply_energy_offset()
+
+        assert abs(electrical_sensor._energy_value - 600.541) < 0.001, (
+            f"Expected 600.541 (100 + 500.541 electrical offset) but got {electrical_sensor._energy_value}. "
+            "Regression: electrical sensor applied the thermal offset."
+        )
+        assert abs(electrical_sensor._applied_offset - 500.541) < 0.001
+
+
+# ===========================================================================
+# 5b. Energy offset – applied via async_added_to_hass() (end-to-end regression)
+#
+# Pre-fix: _apply_energy_offset() existed and was correctly implemented but was
+# never called. async_added_to_hass() on LambdaEnergyConsumptionSensor returned
+# without invoking it, so configured offsets were silently ignored after every
+# HA restart.
+#
+# These tests call async_added_to_hass() with mocked HA internals and assert the
+# final energy value — they FAIL with the old code and PASS with the fix.
+# ===========================================================================
+
+class TestEnergyOffsetAppliedViaAsyncAddedToHass:
+    """
+    Regression tests: _apply_energy_offset() must be called from async_added_to_hass().
+
+    Pre-fix: _apply_energy_offset() existed and was correctly implemented but was
+    never invoked during startup. async_added_to_hass() called restore_state() and
+    optionally _apply_persisted_energy_state() (which overwrites _energy_value with
+    the coordinator's raw persisted value) — but never called _apply_energy_offset().
+    Configured offsets were silently ignored after every HA restart.
+
+    Fix: _apply_energy_offset() is now called at the end of async_added_to_hass(),
+    after _apply_persisted_energy_state(), so the offset is applied on top of whatever
+    raw value the coordinator restored.
+    """
+
+    def _make_last_state(self, value: float, applied_offset: float = 0.0):
+        state = Mock()
+        state.state = str(value)
+        state.attributes = {"applied_offset": applied_offset}
+        return state
+
+    def _run_async_added_to_hass(self, sensor, last_state, coordinator_state=None, config=None):
+        """Helper: run async_added_to_hass() with mocked dependencies.
+
+        Patches out the HA framework methods that can't run in unit tests:
+          - super().async_added_to_hass() → no-op
+          - async_get_last_state() → last_state
+          - _get_energy_sensor_persisted_state_from_coordinator() → coordinator_state
+          - async_dispatcher_connect → no-op (signal handler registration)
+        """
+        from unittest.mock import patch, AsyncMock, MagicMock
+        from custom_components.lambda_heat_pumps.sensor import LambdaEnergyConsumptionSensor
+
+        patches = [
+            patch.object(
+                LambdaEnergyConsumptionSensor,
+                "async_added_to_hass",
+                wraps=sensor.async_added_to_hass,
+            ),
+        ]
+        ctx_super = patch(
+            "homeassistant.helpers.entity.Entity.async_added_to_hass",
+            new=AsyncMock(),
+        )
+        ctx_last_state = patch.object(
+            sensor, "async_get_last_state", return_value=last_state
+        )
+        ctx_coord_state = patch.object(
+            sensor,
+            "_get_energy_sensor_persisted_state_from_coordinator",
+            return_value=coordinator_state,
+        )
+        ctx_dispatcher = patch(
+            "custom_components.lambda_heat_pumps.sensor.async_dispatcher_connect",
+            return_value=Mock(),
+        )
+        ctx_config = patch(
+            "custom_components.lambda_heat_pumps.utils.load_lambda_config",
+            return_value=config or {},
+        )
+
+        import asyncio
+
+        async def _run():
+            async with ctx_super, ctx_last_state, ctx_coord_state, ctx_dispatcher, ctx_config:
+                await sensor.async_added_to_hass()
+
+        return asyncio.get_event_loop().run_until_complete(_run())
+
+    @pytest.mark.asyncio
+    async def test_offset_applied_to_total_sensor_via_async_added_to_hass(self, mock_entry, mock_coordinator):
+        """async_added_to_hass() must apply the configured energy offset to total sensors.
+
+        Pre-fix: _apply_energy_offset() was never called → sensor stayed at restored
+        value (1000.0) instead of offset value (1500.541).
+        """
+        from custom_components.lambda_heat_pumps.sensor import LambdaEnergyConsumptionSensor
+
+        sensor = make_energy_sensor(mock_entry, mock_coordinator, mode="hot_water", period="total")
+        last_state = self._make_last_state(1000.0, applied_offset=0.0)
+        config = {"energy_consumption_offsets": {"hp1": {"hot_water_energy_total": 500.541}}}
+
+        with patch("homeassistant.helpers.entity.Entity.async_added_to_hass", new=AsyncMock()):
+            with patch.object(sensor, "async_get_last_state", return_value=last_state):
+                with patch.object(sensor, "_get_energy_sensor_persisted_state_from_coordinator", return_value=None):
+                    with patch("custom_components.lambda_heat_pumps.sensor.async_dispatcher_connect", return_value=Mock()):
+                        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+                            await sensor.async_added_to_hass()
+
+        assert abs(sensor._energy_value - 1500.541) < 0.001, (
+            f"Expected 1500.541 (1000.0 restored + 500.541 offset) but got {sensor._energy_value}. "
+            "Regression: _apply_energy_offset() not called from async_added_to_hass()."
+        )
+        assert abs(sensor._applied_offset - 500.541) < 0.001
+
+    @pytest.mark.asyncio
+    async def test_offset_not_applied_twice_on_second_restart(self, mock_entry, mock_coordinator):
+        """On a second HA restart with the same offset, the value must not grow.
+
+        _applied_offset is persisted in state attributes and restored. The
+        differential tracking must prevent double-application.
+        """
+        sensor = make_energy_sensor(mock_entry, mock_coordinator, mode="hot_water", period="total")
+        # Simulate second restart: value already includes offset, applied_offset already set
+        last_state = self._make_last_state(1500.541, applied_offset=500.541)
+        config = {"energy_consumption_offsets": {"hp1": {"hot_water_energy_total": 500.541}}}
+
+        with patch("homeassistant.helpers.entity.Entity.async_added_to_hass", new=AsyncMock()):
+            with patch.object(sensor, "async_get_last_state", return_value=last_state):
+                with patch.object(sensor, "_get_energy_sensor_persisted_state_from_coordinator", return_value=None):
+                    with patch("custom_components.lambda_heat_pumps.sensor.async_dispatcher_connect", return_value=Mock()):
+                        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+                            await sensor.async_added_to_hass()
+
+        assert abs(sensor._energy_value - 1500.541) < 0.001, (
+            f"Expected 1500.541 (offset not re-applied) but got {sensor._energy_value}. "
+            "Regression: differential tracking failed — offset applied twice."
+        )
+
+    @pytest.mark.asyncio
+    async def test_offset_applied_after_coordinator_persisted_state_overwrites(self, mock_entry, mock_coordinator):
+        """Offset must be applied AFTER _apply_persisted_energy_state().
+
+        Scenario: restore_state() sets _energy_value = 1500.541 (with offset already in
+        state), then _apply_persisted_energy_state() overwrites with raw coordinator
+        value 1000.0. The offset (500.541) must still be applied on top → 1500.541.
+        """
+        sensor = make_energy_sensor(mock_entry, mock_coordinator, mode="hot_water", period="total")
+        # last_state has the offset already applied (from previous session)
+        last_state = self._make_last_state(1500.541, applied_offset=500.541)
+        # Coordinator persisted state has raw value (no offset)
+        coordinator_state = {"attributes": {"energy_value": 1000.0, "applied_offset": 0.0}}
+        config = {"energy_consumption_offsets": {"hp1": {"hot_water_energy_total": 500.541}}}
+
+        with patch("homeassistant.helpers.entity.Entity.async_added_to_hass", new=AsyncMock()):
+            with patch.object(sensor, "async_get_last_state", return_value=last_state):
+                with patch.object(sensor, "_get_energy_sensor_persisted_state_from_coordinator", return_value=coordinator_state):
+                    with patch("custom_components.lambda_heat_pumps.sensor.async_dispatcher_connect", return_value=Mock()):
+                        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+                            await sensor.async_added_to_hass()
+
+        assert abs(sensor._energy_value - 1500.541) < 0.001, (
+            f"Expected 1500.541 (coordinator raw 1000.0 + offset 500.541) but got {sensor._energy_value}. "
+            "Regression: offset not applied after _apply_persisted_energy_state() overwrote the value."
+        )
+
+    @pytest.mark.asyncio
+    async def test_offset_applied_when_coordinator_json_has_no_applied_offset_field(self, mock_entry, mock_coordinator):
+        """Offset must be applied when coordinator JSON has no applied_offset field (old format).
+
+        Scenario (user's actual bug): HA state has applied_offset=500.54 from a previous
+        session where _apply_energy_offset() ran but the coordinator JSON was never flushed
+        with the updated value. The old coordinator JSON has energy_value=60.53 (raw) and
+        no applied_offset key. Without the fix, _apply_persisted_energy_state() leaves
+        _applied_offset=500.54 from HA state → diff=0 → offset not applied → value stays 60.53.
+
+        Fix: when applied_offset is absent from coordinator JSON, reset it to 0 so the full
+        offset is re-applied on top of the coordinator's raw value.
+        """
+        sensor = make_energy_sensor(mock_entry, mock_coordinator, mode="hot_water", period="total")
+        # HA state from previous session: value=560.53 (with offset), applied_offset=500.541
+        last_state = self._make_last_state(560.53, applied_offset=500.541)
+        # OLD coordinator JSON: energy_value=60.53 (raw), no applied_offset field (pre-fix format)
+        coordinator_state = {"attributes": {"energy_value": 60.53}}  # no applied_offset key
+        config = {"energy_consumption_offsets": {"hp1": {"hot_water_energy_total": 500.541}}}
+
+        # Wrap coordinator_state so _apply_persisted_energy_state gets the right dict shape
+        # (it calls data.get("attributes"))
+        with patch("homeassistant.helpers.entity.Entity.async_added_to_hass", new=AsyncMock()):
+            with patch.object(sensor, "async_get_last_state", return_value=last_state):
+                with patch.object(sensor, "_get_energy_sensor_persisted_state_from_coordinator", return_value=coordinator_state):
+                    with patch("custom_components.lambda_heat_pumps.sensor.async_dispatcher_connect", return_value=Mock()):
+                        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value=config):
+                            await sensor.async_added_to_hass()
+
+        assert abs(sensor._energy_value - 561.071) < 0.01, (
+            f"Expected ~561.071 (coordinator raw 60.53 + offset 500.541) but got {sensor._energy_value}. "
+            "Regression: old coordinator JSON (no applied_offset field) caused offset to be skipped — "
+            "applied_offset from HA state was mistakenly used as the base."
+        )
+        assert abs(sensor._applied_offset - 500.541) < 0.001
+
+    @pytest.mark.asyncio
+    async def test_apply_energy_offset_called_from_async_added_to_hass(self, mock_entry, mock_coordinator):
+        """_apply_energy_offset must be invoked from async_added_to_hass() for total sensors.
+
+        This is the explicit call-site test: even if the value arithmetic changes,
+        the call itself must happen.
+        """
+        sensor = make_energy_sensor(mock_entry, mock_coordinator, mode="heating", period="total")
+
+        with patch("homeassistant.helpers.entity.Entity.async_added_to_hass", new=AsyncMock()):
+            with patch.object(sensor, "async_get_last_state", return_value=None):
+                with patch.object(sensor, "_get_energy_sensor_persisted_state_from_coordinator", return_value=None):
+                    with patch("custom_components.lambda_heat_pumps.sensor.async_dispatcher_connect", return_value=Mock()):
+                        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value={}):
+                            with patch.object(sensor, "_apply_energy_offset", new_callable=AsyncMock) as mock_apply:
+                                await sensor.async_added_to_hass()
+
+        mock_apply.assert_called_once(), (
+            "Regression: _apply_energy_offset() was not called from async_added_to_hass(). "
+            "Energy offsets are silently ignored after every HA restart."
+        )
+
+    @pytest.mark.asyncio
+    async def test_apply_energy_offset_not_called_for_daily_sensor(self, mock_entry, mock_coordinator):
+        """_apply_energy_offset must NOT be called from async_added_to_hass() for daily sensors."""
+        sensor = make_energy_sensor(mock_entry, mock_coordinator, mode="heating", period="daily")
+        last_state = Mock()
+        last_state.state = "5.0"
+        last_state.attributes = {"applied_offset": 0.0, "yesterday_value": 0.0, "energy_value": 5.0}
+
+        with patch("homeassistant.helpers.entity.Entity.async_added_to_hass", new=AsyncMock()):
+            with patch.object(sensor, "async_get_last_state", return_value=last_state):
+                with patch.object(sensor, "_get_energy_sensor_persisted_state_from_coordinator", return_value=None):
+                    with patch("custom_components.lambda_heat_pumps.sensor.async_dispatcher_connect", return_value=Mock()):
+                        with patch("custom_components.lambda_heat_pumps.utils.load_lambda_config", return_value={}):
+                            with patch.object(sensor, "_apply_energy_offset", new_callable=AsyncMock) as mock_apply:
+                                # Patch asyncio.sleep to avoid real delay in daily init path
+                                with patch("asyncio.sleep", new=AsyncMock()):
+                                    with patch.object(sensor, "_initialize_daily_yesterday_value", new=AsyncMock(return_value=False)):
+                                        await sensor.async_added_to_hass()
+
+        mock_apply.assert_not_called(), (
+            "Regression: _apply_energy_offset() called on a daily sensor — "
+            "would corrupt the daily display value."
+        )
 
 
 # ===========================================================================
@@ -580,6 +870,108 @@ energy_consumption_offsets:
 
         assert abs(energy_offsets["hp1"]["heating_thermal_energy_total"] - 6500.0) < 0.001
 
+    def _run_offset_warning_check(self, yaml_content):
+        """Helper: parse YAML and run the electrical/thermal mismatch warning logic inline.
+
+        Simulates the check added to load_lambda_config() without requiring the full
+        file-loading machinery.
+        """
+        import yaml, logging
+        raw = yaml.safe_load(yaml_content)
+        offsets_config = raw.get("energy_consumption_offsets", {})
+        _THERMAL_MODES = ("heating", "hot_water", "cooling", "defrost")
+        warnings_emitted = []
+        for device, offsets in offsets_config.items():
+            if not isinstance(offsets, dict):
+                continue
+            for mode in _THERMAL_MODES:
+                elec_key = f"{mode}_energy_total"
+                therm_key = f"{mode}_thermal_energy_total"
+                elec_val = float(offsets.get(elec_key, 0.0))
+                therm_val = float(offsets.get(therm_key, 0.0))
+                if elec_val != 0.0 and therm_val == 0.0:
+                    warnings_emitted.append(("elec_only", device, mode, elec_key, therm_key))
+                elif therm_val != 0.0 and elec_val == 0.0:
+                    warnings_emitted.append(("therm_only", device, mode, therm_key, elec_key))
+        return warnings_emitted
+
+    def test_warns_when_electrical_set_but_thermal_missing(self):
+        """Mismatch check fires when electrical offset is set but thermal is absent."""
+        yaml_content = """
+energy_consumption_offsets:
+  hp1:
+    hot_water_energy_total: 500.541
+"""
+        warnings = self._run_offset_warning_check(yaml_content)
+        assert len(warnings) == 1
+        kind, device, mode, set_key, missing_key = warnings[0]
+        assert kind == "elec_only"
+        assert device == "hp1"
+        assert mode == "hot_water"
+        assert set_key == "hot_water_energy_total"
+        assert missing_key == "hot_water_thermal_energy_total"
+
+    def test_warns_when_thermal_set_but_electrical_missing(self):
+        """Mismatch check fires when thermal offset is set but electrical is absent."""
+        yaml_content = """
+energy_consumption_offsets:
+  hp1:
+    heating_thermal_energy_total: 6500.0
+"""
+        warnings = self._run_offset_warning_check(yaml_content)
+        assert len(warnings) == 1
+        kind, device, mode, set_key, missing_key = warnings[0]
+        assert kind == "therm_only"
+        assert mode == "heating"
+        assert set_key == "heating_thermal_energy_total"
+        assert missing_key == "heating_energy_total"
+
+    def test_warns_for_each_mismatched_mode_independently(self):
+        """Two mismatched modes produce two warnings."""
+        yaml_content = """
+energy_consumption_offsets:
+  hp1:
+    heating_energy_total: 1000.0
+    hot_water_thermal_energy_total: 2556.089
+"""
+        warnings = self._run_offset_warning_check(yaml_content)
+        assert len(warnings) == 2
+        modes = {w[2] for w in warnings}
+        assert modes == {"heating", "hot_water"}
+
+    def test_no_warning_when_both_offsets_set(self):
+        """No mismatch warning when both electrical and thermal offsets are set."""
+        yaml_content = """
+energy_consumption_offsets:
+  hp1:
+    hot_water_energy_total: 500.541
+    hot_water_thermal_energy_total: 2556.089
+"""
+        warnings = self._run_offset_warning_check(yaml_content)
+        assert warnings == [], f"No warning expected, got: {warnings}"
+
+    def test_no_warning_when_both_offsets_zero(self):
+        """No mismatch warning when both electrical and thermal are 0 (default/disabled)."""
+        yaml_content = """
+energy_consumption_offsets:
+  hp1:
+    heating_energy_total: 0
+    heating_thermal_energy_total: 0
+"""
+        warnings = self._run_offset_warning_check(yaml_content)
+        assert warnings == [], f"No warning expected for zero offsets, got: {warnings}"
+
+    def test_no_warning_for_stby_mode(self):
+        """stby mode has no thermal sensor, so no mismatch check is needed."""
+        yaml_content = """
+energy_consumption_offsets:
+  hp1:
+    stby_energy_total: 50.0
+"""
+        warnings = self._run_offset_warning_check(yaml_content)
+        # stby is not in _THERMAL_MODES → no warning
+        assert warnings == [], f"stby should not trigger thermal mismatch warning, got: {warnings}"
+
 
 # ===========================================================================
 # 8. const_base.py – LAMBDA_WP_CONFIG_TEMPLATE
@@ -763,3 +1155,169 @@ energy_consumption_sensors:
         ]
         for line in cycling_lines:
             assert line in updated, f"Cycling line missing after migration: {line!r}"
+
+
+# ===========================================================================
+# 10. Migration – thermal energy offset lines
+# ===========================================================================
+
+class TestMigrateThermalEnergyOffsets:
+    """Migration inserts missing thermal_energy_total lines in energy_consumption_offsets."""
+
+    # All five section headers present → no template rebuild, tests thermal migration in isolation.
+    # energy_consumption_sensors active so yaml.safe_load returns a non-empty dict.
+    _SECTION_HEADERS = """\
+# Override sensor names (only works if use_legacy_modbus_names is true)
+#sensors_names_override:
+#- id: example
+#  override_name: new_name
+
+# Cycling counter offsets for total sensors
+#cycling_offsets:
+#  hp1:
+#    heating_cycling_total: 0
+#    hot_water_cycling_total: 0
+#    cooling_cycling_total: 0
+#    defrost_cycling_total: 0
+#    compressor_start_cycling_total: 0
+
+# Energy consumption sensor configuration
+energy_consumption_sensors:
+  hp1:
+    sensor_entity_id: "sensor.test"
+    # thermal_sensor_entity_id: "sensor.test_thermal"  # optional
+
+"""
+
+    # File with only electrical offsets (no thermal lines at all)
+    _YAML_ELECTRICAL_ONLY = _SECTION_HEADERS + """\
+# Energy consumption offsets for total sensors
+#energy_consumption_offsets:
+#  hp1:
+#    heating_energy_total: 0.0
+#    hot_water_energy_total: 0.0
+#    cooling_energy_total: 0.0
+#    defrost_energy_total: 0.0
+#  hp2:
+#    heating_energy_total: 150.5
+#    hot_water_energy_total: 45.25
+#    cooling_energy_total: 12.8
+#    defrost_energy_total: 3.1
+
+# Modbus configuration
+#modbus:
+#  int32_register_order: "high_first"
+"""
+
+    # File already has all 4 thermal lines for both hp blocks
+    _YAML_ALL_THERMAL = _SECTION_HEADERS + """\
+# Energy consumption offsets for total sensors
+#energy_consumption_offsets:
+#  hp1:
+#    heating_energy_total: 0.0
+#    hot_water_energy_total: 0.0
+#    cooling_energy_total: 0.0
+#    defrost_energy_total: 0.0
+#    heating_thermal_energy_total: 0.0
+#    hot_water_thermal_energy_total: 0.0
+#    cooling_thermal_energy_total: 0.0
+#    defrost_thermal_energy_total: 0.0
+
+# Modbus configuration
+#modbus:
+#  int32_register_order: "high_first"
+"""
+
+    # File with only the first two thermal lines (partial migration state)
+    _YAML_PARTIAL_THERMAL = _SECTION_HEADERS + """\
+# Energy consumption offsets for total sensors
+#energy_consumption_offsets:
+#  hp1:
+#    heating_energy_total: 0.0
+#    hot_water_energy_total: 0.0
+#    cooling_energy_total: 0.0
+#    defrost_energy_total: 0.0
+#    heating_thermal_energy_total: 0.0
+#    hot_water_thermal_energy_total: 0.0
+
+# Modbus configuration
+#modbus:
+#  int32_register_order: "high_first"
+"""
+
+    def _make_hass(self, tmp_path, content):
+        config_path = tmp_path / "lambda_wp_config.yaml"
+        config_path.write_text(content, encoding="utf-8")
+        hass = Mock()
+        hass.config.config_dir = str(tmp_path)
+        async def fake_executor(fn, *args):
+            return fn(*args) if args else fn()
+        hass.async_add_executor_job = fake_executor
+        return hass, config_path
+
+    @pytest.mark.asyncio
+    async def test_adds_all_four_thermal_lines_when_missing(self, tmp_path):
+        """All 4 thermal_energy_total lines are inserted after defrost_energy_total."""
+        from custom_components.lambda_heat_pumps.migration import migrate_lambda_config_sections
+        hass, config_path = self._make_hass(tmp_path, self._YAML_ELECTRICAL_ONLY)
+
+        result = await migrate_lambda_config_sections(hass)
+
+        assert result is True
+        updated = config_path.read_text(encoding="utf-8")
+        for key in ["heating_thermal_energy_total:", "hot_water_thermal_energy_total:",
+                    "cooling_thermal_energy_total:", "defrost_thermal_energy_total:"]:
+            assert key in updated, f"Missing after migration: {key}"
+
+    @pytest.mark.asyncio
+    async def test_thermal_lines_inserted_after_defrost_energy(self, tmp_path):
+        """heating_thermal_energy_total appears after defrost_energy_total in the file."""
+        from custom_components.lambda_heat_pumps.migration import migrate_lambda_config_sections
+        hass, config_path = self._make_hass(tmp_path, self._YAML_ELECTRICAL_ONLY)
+
+        await migrate_lambda_config_sections(hass)
+
+        updated = config_path.read_text(encoding="utf-8")
+        defrost_pos = updated.find("defrost_energy_total: 0.0")
+        thermal_pos = updated.find("heating_thermal_energy_total:", defrost_pos)
+        assert thermal_pos > defrost_pos
+
+    @pytest.mark.asyncio
+    async def test_skips_when_all_thermal_present(self, tmp_path):
+        """No thermal lines are duplicated when all 4 are already present."""
+        from custom_components.lambda_heat_pumps.migration import migrate_lambda_config_sections
+        hass, config_path = self._make_hass(tmp_path, self._YAML_ALL_THERMAL)
+        original_count = self._YAML_ALL_THERMAL.count("thermal_energy_total:")
+
+        await migrate_lambda_config_sections(hass)
+
+        updated = config_path.read_text(encoding="utf-8")
+        assert updated.count("thermal_energy_total:") == original_count
+
+    @pytest.mark.asyncio
+    async def test_adds_only_missing_thermal_lines(self, tmp_path):
+        """Only cooling_thermal and defrost_thermal are added when heating and hot_water already present."""
+        from custom_components.lambda_heat_pumps.migration import migrate_lambda_config_sections
+        hass, config_path = self._make_hass(tmp_path, self._YAML_PARTIAL_THERMAL)
+
+        result = await migrate_lambda_config_sections(hass)
+
+        assert result is True
+        updated = config_path.read_text(encoding="utf-8")
+        assert updated.count("heating_thermal_energy_total:") == 1   # not duplicated
+        assert updated.count("hot_water_thermal_energy_total:") == 1  # not duplicated
+        assert "cooling_thermal_energy_total:" in updated             # newly added
+        assert "defrost_thermal_energy_total:" in updated             # newly added
+
+    @pytest.mark.asyncio
+    async def test_thermal_lines_inserted_for_multiple_hp_blocks(self, tmp_path):
+        """Thermal lines are added for every hp-block that has defrost_energy_total."""
+        from custom_components.lambda_heat_pumps.migration import migrate_lambda_config_sections
+        hass, config_path = self._make_hass(tmp_path, self._YAML_ELECTRICAL_ONLY)
+
+        await migrate_lambda_config_sections(hass)
+
+        updated = config_path.read_text(encoding="utf-8")
+        # Two hp-blocks (hp1, hp2) → each gets 4 thermal lines → 8 total
+        assert updated.count("heating_thermal_energy_total:") == 2
+        assert updated.count("defrost_thermal_energy_total:") == 2

--- a/tests/test_offset_features.py
+++ b/tests/test_offset_features.py
@@ -605,3 +605,161 @@ class TestConfigTemplate:
         """The template must include compressor_start_cycling_total as a commented example."""
         from custom_components.lambda_heat_pumps.const_base import LAMBDA_WP_CONFIG_TEMPLATE
         assert "compressor_start_cycling_total" in LAMBDA_WP_CONFIG_TEMPLATE
+
+
+# ===========================================================================
+# 9. Migration – compressor_start_cycling_total
+# ===========================================================================
+
+class TestMigrateCyclingOffsetCompressorStart:
+    """Migration adds compressor_start_cycling_total after defrost_cycling_total if absent."""
+
+    # Minimal lambda_wp_config.yaml WITHOUT compressor_start_cycling_total
+    _YAML_WITHOUT = """\
+# Cycling counter offsets for total sensors
+# These offsets are added to the calculated cycling counts
+# Useful when replacing heat pumps or resetting counters
+# Example:
+#cycling_offsets:
+#  hp1:
+#    heating_cycling_total: 0      # Offset for HP1 heating total cycles
+#    hot_water_cycling_total: 0    # Offset for HP1 hot water total cycles
+#    cooling_cycling_total: 0      # Offset for HP1 cooling total cycles
+#    defrost_cycling_total: 0      # Offset for HP1 defrost total cycles
+#  hp2:
+#    heating_cycling_total: 1500   # Example
+#    hot_water_cycling_total: 800  # Example
+#    cooling_cycling_total: 200    # Example
+#    defrost_cycling_total: 50     # Example
+
+# Energy consumption sensor configuration
+energy_consumption_sensors:
+  hp1:
+    sensor_entity_id: "sensor.test"
+    # thermal_sensor_entity_id: "sensor.test_thermal"  # optional
+"""
+
+    # Same file but WITH compressor_start_cycling_total already present
+    _YAML_WITH = """\
+# Cycling counter offsets for total sensors
+# These offsets are added to the calculated cycling counts
+# Useful when replacing heat pumps or resetting counters
+# Example:
+#cycling_offsets:
+#  hp1:
+#    heating_cycling_total: 0
+#    hot_water_cycling_total: 0
+#    cooling_cycling_total: 0
+#    defrost_cycling_total: 0
+#    compressor_start_cycling_total: 0      # Offset for compressor start total
+#  hp2:
+#    heating_cycling_total: 1500
+#    hot_water_cycling_total: 800
+#    cooling_cycling_total: 200
+#    defrost_cycling_total: 50
+#    compressor_start_cycling_total: 0      # Offset for compressor start total
+
+# Energy consumption sensor configuration
+energy_consumption_sensors:
+  hp1:
+    sensor_entity_id: "sensor.test"
+    # thermal_sensor_entity_id: "sensor.test_thermal"  # optional
+"""
+
+    # Active (uncommented) cycling_offsets without compressor_start_cycling_total
+    _YAML_ACTIVE = """\
+# Cycling counter offsets for total sensors
+cycling_offsets:
+  hp1:
+    heating_cycling_total: 100
+    hot_water_cycling_total: 50
+    cooling_cycling_total: 10
+    defrost_cycling_total: 5
+
+# Energy consumption sensor configuration
+energy_consumption_sensors:
+  hp1:
+    sensor_entity_id: "sensor.test"
+    # thermal_sensor_entity_id: "sensor.test_thermal"  # optional
+"""
+
+    def _make_hass(self, tmp_path, content):
+        config_path = tmp_path / "lambda_wp_config.yaml"
+        config_path.write_text(content, encoding="utf-8")
+        hass = Mock()
+        hass.config.config_dir = str(tmp_path)
+        # async_add_executor_job executes sync callables synchronously in tests
+        async def fake_executor(fn, *args):
+            return fn(*args) if args else fn()
+        hass.async_add_executor_job = fake_executor
+        return hass, config_path
+
+    @pytest.mark.asyncio
+    async def test_adds_line_when_missing(self, tmp_path):
+        """compressor_start_cycling_total is inserted after each defrost_cycling_total."""
+        from custom_components.lambda_heat_pumps.migration import migrate_lambda_config_sections
+        hass, config_path = self._make_hass(tmp_path, self._YAML_WITHOUT)
+
+        result = await migrate_lambda_config_sections(hass)
+
+        assert result is True
+        updated = config_path.read_text(encoding="utf-8")
+        assert "compressor_start_cycling_total:" in updated
+        # Must appear after defrost_cycling_total in the file
+        defrost_pos = updated.find("defrost_cycling_total: 0      # Offset")
+        compressor_pos = updated.find("compressor_start_cycling_total:", defrost_pos)
+        assert compressor_pos > defrost_pos
+
+    @pytest.mark.asyncio
+    async def test_skips_when_already_present(self, tmp_path):
+        """compressor_start_cycling_total is not duplicated when already present."""
+        from custom_components.lambda_heat_pumps.migration import migrate_lambda_config_sections
+        hass, config_path = self._make_hass(tmp_path, self._YAML_WITH)
+        original_count = self._YAML_WITH.count("compressor_start_cycling_total:")
+
+        await migrate_lambda_config_sections(hass)
+
+        updated = config_path.read_text(encoding="utf-8")
+        # Count must not increase — no duplicate insertion
+        assert updated.count("compressor_start_cycling_total:") == original_count
+
+    @pytest.mark.asyncio
+    async def test_handles_active_cycling_offsets(self, tmp_path):
+        """Active (uncommented) cycling_offsets section also gets the line added."""
+        from custom_components.lambda_heat_pumps.migration import migrate_lambda_config_sections
+        hass, config_path = self._make_hass(tmp_path, self._YAML_ACTIVE)
+
+        result = await migrate_lambda_config_sections(hass)
+
+        assert result is True
+        updated = config_path.read_text(encoding="utf-8")
+        assert "compressor_start_cycling_total:" in updated
+        # Should NOT be commented out (prefix is spaces, not #)
+        for line in updated.splitlines():
+            if "compressor_start_cycling_total:" in line:
+                assert not line.lstrip().startswith("#"), (
+                    "Active cycling_offsets: compressor line must not be commented out"
+                )
+                break
+
+    @pytest.mark.asyncio
+    async def test_preserves_other_content(self, tmp_path):
+        """Existing cycling offset lines are preserved; only compressor line is added."""
+        from custom_components.lambda_heat_pumps.migration import migrate_lambda_config_sections
+        hass, config_path = self._make_hass(tmp_path, self._YAML_WITHOUT)
+
+        await migrate_lambda_config_sections(hass)
+
+        updated = config_path.read_text(encoding="utf-8")
+        # All original cycling-offsets example lines must still be present
+        cycling_lines = [
+            "#cycling_offsets:",
+            "#    heating_cycling_total: 0      # Offset for HP1 heating total cycles",
+            "#    hot_water_cycling_total: 0    # Offset for HP1 hot water total cycles",
+            "#    cooling_cycling_total: 0      # Offset for HP1 cooling total cycles",
+            "#    defrost_cycling_total: 0      # Offset for HP1 defrost total cycles",
+            "#    heating_cycling_total: 1500   # Example",
+            "#    defrost_cycling_total: 50     # Example",
+        ]
+        for line in cycling_lines:
+            assert line in updated, f"Cycling line missing after migration: {line!r}"


### PR DESCRIPTION
# Release 2.4.0

*Last modified: 2026-04-04*

> **Current Release** `V2.4.0`

---

## Summary

Release 2.4.0 fixes several bugs: a critical error in the cycling sensor offset logic (offsets were re-added on every cycle event), a bug in mode detection for cycling counters (missed cycles due to shared state), a further critical bug where operating mode transitions were correctly detected but never counted (`cycling_entity` NameError in `increment_cycling_counter()`), and a bug where configured energy offsets were silently ignored at HA startup (`_apply_energy_offset()` was never called from `async_added_to_hass()`). Additionally, the configuration template, migration system, test suite, and documentation were fully updated.